### PR TITLE
fix: relax power tuning

### DIFF
--- a/nixos/profiles/laptop/power.nix
+++ b/nixos/profiles/laptop/power.nix
@@ -2,11 +2,7 @@
 # Power management for ThinkPad T14 Gen 1 laptops.
 # TLP and power-profiles-daemon are mutually exclusive; KDE Plasma enables PPD
 # by default, so we explicitly disable it here.
-{
-  pkgs,
-  lib,
-  ...
-}: {
+{lib, ...}: {
   services.power-profiles-daemon.enable = lib.mkForce false;
 
   services.tlp = {
@@ -14,17 +10,17 @@
     settings = {
       # CPU scaling governor and energy/performance policy
       CPU_SCALING_GOVERNOR_ON_AC = "performance";
-      CPU_SCALING_GOVERNOR_ON_BAT = "powersave";
+      CPU_SCALING_GOVERNOR_ON_BAT = "schedutil";
       CPU_ENERGY_PERF_POLICY_ON_AC = "balance_performance";
-      CPU_ENERGY_PERF_POLICY_ON_BAT = "power";
+      CPU_ENERGY_PERF_POLICY_ON_BAT = "balance_power";
 
-      # Turbo boost: on when plugged in, off on battery
+      # Turbo boost: always on; EPP/governor manage the power/perf tradeoff
       CPU_BOOST_ON_AC = 1;
-      CPU_BOOST_ON_BAT = 0;
+      CPU_BOOST_ON_BAT = 1;
 
       # Platform profiles (Intel Mode 2 power management)
       PLATFORM_PROFILE_ON_AC = "balanced";
-      PLATFORM_PROFILE_ON_BAT = "low-power";
+      PLATFORM_PROFILE_ON_BAT = "balanced";
 
       # NVMe power saving
       PCIE_ASPM_ON_AC = "default";
@@ -51,6 +47,6 @@
     HandleLidSwitchExternalPower = "suspend";
     HandlePowerKey = "suspend";
     IdleAction = "suspend";
-    IdleActionSec = "30min";
+    IdleActionSec = "300";
   };
 }


### PR DESCRIPTION
This pull request updates the power management profile for ThinkPad T14 Gen 1 laptops, focusing on optimizing CPU power settings and improving consistency between AC and battery modes. The changes primarily refine CPU scaling, energy policies, turbo boost behavior, and platform profiles, as well as adjust the system's idle suspend timing.

CPU and Power Management Policy Updates:

* Changed `CPU_SCALING_GOVERNOR_ON_BAT` from `"powersave"` to `"schedutil"` for improved responsiveness and efficiency on battery.
* Updated `CPU_ENERGY_PERF_POLICY_ON_BAT` from `"power"` to `"balance_power"` to better balance performance and battery life.
* Set `CPU_BOOST_ON_BAT` to `1` (was `0`), so turbo boost is always enabled; power/performance tradeoff is now managed by governor and EPP settings.
* Changed `PLATFORM_PROFILE_ON_BAT` from `"low-power"` to `"balanced"` for more consistent performance between AC and battery modes.

System Suspend Behavior:

* Adjusted `IdleActionSec` from `"30min"` to `"300"` (seconds), reducing the idle suspend timeout from 30 minutes to 5 minutes for quicker power saving.