### PR TITLE
Fix type from string to bool

### DIFF
--- a/home/modules/starship/default.nix
+++ b/home/modules/starship/default.nix
@@ -117,7 +117,7 @@
       status = {
         disabled = false;
         symbol = " ";
-        map_symbol = "true";
+        map_symbol = true;
         not_executable_symbol = " ";
         not_found_symbol = " ";
         sigint_symbol = "󰗖 ";


### PR DESCRIPTION
This pull request makes a minor update to the `home/modules/starship/default.nix` configuration file, correcting the value of the `map_symbol` property from a string to a boolean. This ensures proper type usage in the configuration.

- Changed `map_symbol` from the string value `"true"` to the boolean value `true` in the `status` configuration.