### PR TITLE
Fix curl call to follow redirects in autodeploy-status

### DIFF
--- a/justfile
+++ b/justfile
@@ -268,6 +268,6 @@ autodeploy-resume host:
 # Usage: just autodeploy-status wendigo
 [group('autodeploy')]
 autodeploy-status host=hostname:
-    @curl -sf "https://asphaltbuffet.github.io/nix-config/hosts/{{ host }}/store-path" \
+    @curl -sfL "https://asphaltbuffet.github.io/nix-config/hosts/{{ host }}/store-path" \
         && echo "" \
         || echo "No store path published yet for {{ host }}"


### PR DESCRIPTION
This pull request makes a minor update to the `autodeploy-status` command in the `justfile` to improve how it fetches the store path for a host.

* Added the `-L` flag to the `curl` command in `autodeploy-status` to ensure it follows HTTP redirects when retrieving the store path for a host.