### PR TITLE
Fix workflow permissions

### DIFF
--- a/.github/workflows/autodeploy.yml
+++ b/.github/workflows/autodeploy.yml
@@ -8,10 +8,51 @@ on:
 permissions: {}
 
 jobs:
-  build-and-publish:
+  build:
     uses: ./.github/workflows/build-hosts.yml
+    permissions:
+      contents: read
     with:
       publish-pages: true
     secrets:
       CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
       CACHIX_SIGNING_KEY: ${{ secrets.CACHIX_SIGNING_KEY }}
+
+  publish:
+    name: "publish to GitHub Pages"
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+
+    steps:
+      - name: Download all pages fragments
+        uses: actions/download-artifact@v4
+        with:
+          pattern: pages-*
+          merge-multiple: true
+          path: pages-artifact/
+
+      # Ensure the artifact directory is never empty — upload-pages-artifact fails
+      # on an empty directory. This handles the edge case where all hosts are skipped.
+      - name: Ensure non-empty artifact
+        run: |
+          shopt -s nullglob
+          files=(pages-artifact/*)
+          if [ ${#files[@]} -eq 0 ]; then
+            mkdir -p pages-artifact
+            echo "All hosts skipped — no store paths updated." > pages-artifact/index.html
+          fi
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: pages-artifact/
+
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/build-hosts.yml
+++ b/.github/workflows/build-hosts.yml
@@ -1,6 +1,7 @@
 name: "build hosts"
-# Reusable workflow: build all NixOS hosts and optionally publish store paths to GitHub Pages.
-# Called by autodeploy.yml (publish-pages: true) and update_flake_lock.yaml (publish-pages: false).
+# Reusable workflow: build all NixOS hosts and push store paths to Cachix.
+# Called by autodeploy.yml, pr-check.yml, and update_flake_lock.yaml.
+# Store path artifacts are uploaded when publish-pages: true, for the caller to deploy.
 
 on:
   workflow_call:
@@ -11,7 +12,7 @@ on:
         required: false
         default: ""
       publish-pages:
-        description: "Publish store paths to GitHub Pages for nixos-autodeploy pickup"
+        description: "Upload store path artifacts for GitHub Pages publishing"
         type: boolean
         required: false
         default: false
@@ -106,43 +107,3 @@ jobs:
           name: pages-${{ matrix.host }}
           path: pages-artifact/
           if-no-files-found: ignore
-
-  publish:
-    name: "publish to GitHub Pages"
-    needs: [generate-matrix, build]
-    if: inputs.publish-pages
-    runs-on: ubuntu-latest
-    permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deploy.outputs.page_url }}
-
-    steps:
-      - name: Download all pages fragments
-        uses: actions/download-artifact@v4
-        with:
-          pattern: pages-*
-          merge-multiple: true
-          path: pages-artifact/
-
-      # Ensure the artifact directory is never empty — upload-pages-artifact fails
-      # on an empty directory. This handles the edge case where all hosts are skipped.
-      - name: Ensure non-empty artifact
-        run: |
-          shopt -s nullglob
-          files=(pages-artifact/*)
-          if [ ${#files[@]} -eq 0 ]; then
-            mkdir -p pages-artifact
-            echo "All hosts skipped — no store paths updated." > pages-artifact/index.html
-          fi
-
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: pages-artifact/
-
-      - name: Deploy to GitHub Pages
-        id: deploy
-        uses: actions/deploy-pages@v4

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -8,8 +8,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 jobs:
   build:

--- a/.github/workflows/update_flake_lock.yaml
+++ b/.github/workflows/update_flake_lock.yaml
@@ -49,6 +49,8 @@ jobs:
     needs: update
     if: needs.update.outputs.branch != ''
     uses: ./.github/workflows/build-hosts.yml
+    permissions:
+      contents: read
     with:
       ref: ${{ needs.update.outputs.branch }}
       publish-pages: false


### PR DESCRIPTION
This pull request refactors the GitHub Actions workflows for building and deploying NixOS hosts, primarily by separating the build and publish steps in the deployment pipeline and clarifying the responsibilities of each workflow. The main goal is to make the build process reusable and modular, and to ensure that publishing to GitHub Pages is handled explicitly and only when needed.

Workflow separation and improvements:

* Split the `build-and-publish` job in `.github/workflows/autodeploy.yml` into two jobs: `build` (which builds and uploads artifacts) and `publish` (which publishes to GitHub Pages using the artifacts from the build job). This makes the deployment process clearer and more modular.
* Removed the `publish` job from `.github/workflows/build-hosts.yml`, so this workflow now only builds and uploads artifacts, leaving publishing to the caller workflow.

Permissions and usage updates:

* Added explicit permissions for the `build` and `publish` jobs in `.github/workflows/autodeploy.yml` and `.github/workflows/update_flake_lock.yaml` to follow least-privilege principles. [[1]](diffhunk://#diff-026e6ce25a2a7bf4ddb9ac3bfb66023ddf22c8cfddf2c6d9bf0a0c3418f30b90L11-R58) [[2]](diffhunk://#diff-db6682ef48ce7f2f6f1eb3a5d85a2d789a5802f98318df6a7211d8f9f795adb9R52-R53)
* Removed unnecessary `pages` and `id-token` permissions from `.github/workflows/pr-check.yml` since this workflow no longer publishes to GitHub Pages.

Documentation and input clarification:

* Updated comments and the `publish-pages` input description in `.github/workflows/build-hosts.yml` to clarify that this workflow uploads store path artifacts for GitHub Pages publishing, but does not perform the publish step itself. [[1]](diffhunk://#diff-5a9469590fcd47aa83899279dca3cc31c0f4d70a63ea55883ab5cdcd16970b7dL2-R4) [[2]](diffhunk://#diff-5a9469590fcd47aa83899279dca3cc31c0f4d70a63ea55883ab5cdcd16970b7dL14-R15)