### PR TITLE
Cache build artifacts in CI

### DIFF
--- a/.github/workflows/autodeploy.yml
+++ b/.github/workflows/autodeploy.yml
@@ -10,8 +10,6 @@ permissions: {}
 jobs:
   build:
     uses: ./.github/workflows/build-hosts.yml
-    permissions:
-      contents: read
     with:
       publish-pages: true
     secrets:

--- a/.github/workflows/build-hosts.yml
+++ b/.github/workflows/build-hosts.yml
@@ -62,6 +62,8 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - uses: DeterminateSystems/determinate-nix-action@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # cachix-action installs a Nix post-build hook that automatically pushes
       # all newly built store paths to the cache — no manual `cachix push` needed.

--- a/.github/workflows/update_flake_lock.yaml
+++ b/.github/workflows/update_flake_lock.yaml
@@ -23,6 +23,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: DeterminateSystems/determinate-nix-action@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update flake.lock
         run: nix flake update
@@ -49,8 +51,6 @@ jobs:
     needs: update
     if: needs.update.outputs.branch != ''
     uses: ./.github/workflows/build-hosts.yml
-    permissions:
-      contents: read
     with:
       ref: ${{ needs.update.outputs.branch }}
       publish-pages: false


### PR DESCRIPTION
## Summary

- **Nix Actions cache**: Pass `github-token` to `DeterminateSystems/determinate-nix-action` in both `build-hosts.yml` and `update_flake_lock.yaml`. This enables the Magic Nix Cache, which uses GitHub Actions cache as a secondary Nix store substituter — reducing redundant Cachix fetches across runs.
- **Permission cleanup**: Remove no-op `permissions:` blocks from `workflow_call` jobs in `autodeploy.yml` and `update_flake_lock.yaml`. GitHub Actions silently ignores `permissions:` on reusable workflow call jobs; permissions for those jobs are governed solely by the called workflow's own declarations.

## Security review notes

- `github-token` passed to `determinate-nix-action` is the ephemeral per-job token scoped to `contents: read` only — no elevated risk.
- `ubuntu-latest-4` (4-core runner) was considered but reverted — that label requires a paid GitHub plan and is not available on free accounts.

## Prerequisites

- `GH_BOT_TOKEN` secret must be set on the repo (fine-grained PAT with `contents: write` and `pull-requests: write`) for `update_flake_lock.yaml`'s auto-merge to function.
- Branch protection on `main` should not require human reviews for bot-opened PRs, or auto-merge will stall.

## Related

- Issue #40: future opportunity to skip unchanged hosts in the build matrix (change detection)