### PR TITLE
Fix nix caching

### DIFF
--- a/.github/workflows/build-hosts.yaml
+++ b/.github/workflows/build-hosts.yaml
@@ -56,7 +56,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write # required for Magic Nix Cache OIDC authentication
     strategy:
       fail-fast: false
       matrix:
@@ -67,9 +66,20 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
-      - uses: DeterminateSystems/determinate-nix-action@v3
+      - uses: cachix/install-nix-action@v31
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Cache the Nix store in GitHub Actions cache keyed on flake.lock.
+      # Primary key hits restore the full store; on miss the closest prefix match
+      # is used as a warm starting point. gc-max-store-size keeps the cache under
+      # GitHub's 10 GB per-repo limit.
+      - name: Restore Nix store cache
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-${{ runner.os }}-${{ matrix.host }}-${{ hashFiles('flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ matrix.host }}-
+          gc-max-store-size: 2000000000
 
       # cachix-action installs a Nix post-build hook that automatically pushes
       # all newly built store paths to the cache — no manual `cachix push` needed.

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write # ceiling for Magic Nix Cache OIDC in build-hosts.yaml
 
 jobs:
   build:

--- a/.github/workflows/update_flake_lock.yaml
+++ b/.github/workflows/update_flake_lock.yaml
@@ -15,7 +15,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write # ceiling for Magic Nix Cache OIDC in build-hosts.yaml
 
 jobs:
   update:
@@ -28,9 +27,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: DeterminateSystems/determinate-nix-action@v3
+      - uses: cachix/install-nix-action@v31
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update flake.lock
         run: nix flake update
@@ -80,9 +79,16 @@ jobs:
         # main branch closure as the baseline for nix store diff-closures.
         # The update branch's store paths arrive via downloaded artifacts.
 
-      - uses: DeterminateSystems/determinate-nix-action@v3
+      - uses: cachix/install-nix-action@v31
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Restore Nix store cache
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-${{ runner.os }}-diff-${{ hashFiles('flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-diff-
+          gc-max-store-size: 2000000000
 
       - uses: cachix/cachix-action@v15
         with:


### PR DESCRIPTION
This pull request updates the Nix installation and caching setup in the GitHub Actions workflow. The main focus is on improving CI reliability, cache efficiency, and developer guidance for working with shared workflows.

**CI/CD Workflow Improvements:**

* Switched from `DeterminateSystems/determinate-nix-action@v3` to `cachix/install-nix-action@v31` for installing Nix in `.github/workflows/build-hosts.yaml`, and updated the token input name to `github_access_token` for compatibility.
* Added a new step using `nix-community/cache-nix-action@v7` to restore the Nix store from cache, keyed on `flake.lock`, to speed up builds and manage cache size within GitHub's limits.