### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -53,11 +53,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775506628,
-        "narHash": "sha256-74ZHkdLbi2HqqRo5wWcylehj5fdhBCWqAV5qaWdusLU=",
+        "lastModified": 1775766706,
+        "narHash": "sha256-s2sRQju5tW/vJlJLhl6PIAi613lnl/tChALNZ6LvSPo=",
         "owner": "charmbracelet",
         "repo": "nur",
-        "rev": "28a88b2c895dd5b5d11690d77b5e734144149e86",
+        "rev": "254d53103ee6b1c993255a4b7d30f80b706910ea",
         "type": "github"
       },
       "original": {
@@ -236,11 +236,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775544097,
-        "narHash": "sha256-fwI8PbrUT4W+z+J4TAS/D69So/MLan1WZjUsYQpoSvI=",
+        "lastModified": 1775781825,
+        "narHash": "sha256-L5yKTpR+alrZU2XYYvIxCeCP4LBHU5jhwSj7H1VAavg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2bd16b16a77d68a1e14c1b4da725a6590181a706",
+        "rev": "e35c39fca04fee829cecdf839a50eb9b54d8a701",
         "type": "github"
       },
       "original": {
@@ -378,11 +378,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1775423009,
-        "narHash": "sha256-vPKLpjhIVWdDrfiUM8atW6YkIggCEKdSAlJPzzhkQlw=",
+        "lastModified": 1775710090,
+        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "68d8aa3d661f0e6bd5862291b5bb263b2a6595c9",
+        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
         "type": "github"
       },
       "original": {
@@ -394,11 +394,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1775423009,
-        "narHash": "sha256-vPKLpjhIVWdDrfiUM8atW6YkIggCEKdSAlJPzzhkQlw=",
+        "lastModified": 1775710090,
+        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "68d8aa3d661f0e6bd5862291b5bb263b2a6595c9",
+        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
         "type": "github"
       },
       "original": {
@@ -414,11 +414,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1775550182,
-        "narHash": "sha256-QkxR9QL8KMDpPgATHT989kQ5Mpn2qECxSIvEd4ZJSRk=",
+        "lastModified": 1775808671,
+        "narHash": "sha256-cTykY1Sbn8Klm8crN/1HFE9AtvXcLArv/WhZy7xv2II=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2d2c37c6c95f5bd2606e5d909574c995ade44d72",
+        "rev": "08c92ce076c46e8b875729eab304bc9f7f163fb0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated update of `flake.lock` inputs.

All hosts built successfully against this lock file.
Merging will trigger `autodeploy.yaml`, which publishes store paths for pickup by `nixos-autodeploy`.

## Package changes

**Added: 7 | Removed: 6 | Changed: 106**

<details>
<summary>Full diff</summary>

```
aurorae: 6.6.3 → 6.6.4
bind: 9.20.21 → 9.20.22
bluedevil: 6.6.3 → 6.6.4
breeze-gtk: 6.6.3 → 6.6.4
breeze: 6.6.3, 6.6.3-qt5 → 6.6.4, 6.6.4-qt5
brltty: 6.9 → 6.9.1, [31;1m23.2 KiB[0m
bundler: ∅ → 2.7.2, [31;1m1.9 MiB[0m
crush: 0.55.1 → 0.56.0, [31;1m276.9 KiB[0m
delve: [31;1m34.0 KiB[0m
dhcpcd: 10.3.0 → 10.3.1
dhcpcd: 10.3.0 → 10.3.1, [31;1m8.1 KiB[0m
discover: 6.6.3 → 6.6.4
drkonqi: 6.6.3 → 6.6.4
firefox-unwrapped: 149.0 → 149.0.2, [31;1m143.1 KiB[0m
firefox: 149.0 → 149.0.2, [32;1m-55.6 KiB[0m
flatpak: 1.16.3 → 1.16.4, [31;1m73.9 KiB[0m
gemfile-and: ∅ → ε
home-configuration-reference: [31;1m8.2 KiB[0m
kactivitymanagerd: 6.6.3 → 6.6.4
kde-cli-tools: 6.6.3 → 6.6.4
kde-gtk-config: 6.6.3 → 6.6.4
kdecoration: 6.6.3 → 6.6.4
kdeplasma-addons: 6.6.3 → 6.6.4, [31;1m13.2 KiB[0m
kglobalacceld: 6.6.3 → 6.6.4
kinfocenter: 6.6.3 → 6.6.4
kitty-themes: 0-unstable-2026-03-25 → 0-unstable-2026-03-31
kmenuedit: 6.6.3 → 6.6.4
knighttime: 6.6.3 → 6.6.4
kpipewire: 6.6.3 → 6.6.4
krdp: 6.6.3 → 6.6.4
kscreen: 6.6.3 → 6.6.4
kscreenlocker: 6.6.3 → 6.6.4
ksshaskpass: 6.6.3 → 6.6.4
ksystemstats: 6.6.3 → 6.6.4
kwallet-pam: 6.6.3 → 6.6.4
kwayland-integration: 6.6.3 → 6.6.4
kwayland: 6.6.3 → 6.6.4
kwin-x11: 6.6.3 → 6.6.4, [31;1m28.2 KiB[0m
kwin: 6.6.3 → 6.6.4, [31;1m37.2 KiB[0m
kwrited: 6.6.3 → 6.6.4
layer-shell-qt: 6.6.3 → 6.6.4
libblake3: 1.8.3 → 1.8.4
libkscreen: 6.6.3 → 6.6.4
libksysguard: 6.6.3 → 6.6.4
libplasma: 6.6.3 → 6.6.4, [31;1m16.5 KiB[0m
lua-language-server: 3.17.1 → 3.18.0, [31;1m14.0 KiB[0m
milou: 6.6.3 → 6.6.4
mise: 2026.3.17 → 2026.4.6, [31;1m1.5 MiB[0m
neovim-ruby: ∅ → ε, [31;1m11.2 KiB[0m
neovim-unwrapped: 0.12.0 → 0.12.1, [31;1m13.7 KiB[0m
neovim: 0.12.0 → 0.12.1
nfs-utils: 2.8.7 → 2.9.1, [31;1m20.7 KiB[0m
nix-cmd: 2.30.3+2, 2.31.3+1 → 2.30.4+1, 2.31.4
nix-expr: 2.30.3+2, 2.31.3+1 → 2.30.4+1, 2.31.4
nix-fetchers: 2.30.3+2, 2.31.3+1 → 2.30.4+1, 2.31.4
nix-flake: 2.30.3+2, 2.31.3+1 → 2.30.4+1, 2.31.4
nix-main: 2.30.3+2, 2.31.3+1 → 2.30.4+1, 2.31.4
nix-manual: 2.31.3+1 → 2.31.4
nix-store: 2.30.3+2, 2.31.3+1 → 2.30.4+1, 2.31.4, [31;1m13.8 KiB[0m
nix-util: 2.30.3+2, 2.31.3+1 → 2.30.4+1, 2.31.4
nix: 2.31.3+1 → 2.31.4
nixos-manual: [31;1m11.9 KiB[0m
nixos-system-kushtaka: 26.05.20260405.68d8aa3 → 26.05.20260409.4c1018d
nixos-system-snallygaster: 26.05.20260405.68d8aa3 → 26.05.20260409.4c1018d
nixos-system-wendigo: 26.05.20260405.68d8aa3 → 26.05.20260409.4c1018d
ocean-sound-theme: 6.6.3 → 6.6.4
plasma-activities-stats: 6.6.3 → 6.6.4
plasma-activities: 6.6.3 → 6.6.4
plasma-browser-integration: 6.6.3 → 6.6.4
plasma-desktop: 6.6.3 → 6.6.4, [31;1m60.6 KiB[0m
plasma-integration: 6.6.3, 6.6.3-qt5 → 6.6.4, 6.6.4-qt5
plasma-nano: 6.6.3 → 6.6.4
plasma-nm: 6.6.3 → 6.6.4
plasma-pa: 6.6.3 → 6.6.4
plasma-sdk: 6.6.3 → 6.6.4
plasma-systemmonitor: 6.6.3 → 6.6.4
plasma-workspace-wallpapers: 6.6.3 → 6.6.4
plasma-workspace: 6.6.3 → 6.6.4, [31;1m18.4 KiB[0m
plasma5support: 6.6.3 → 6.6.4
polkit-kde-agent: 1-6.6.3 → 1-6.6.4
powerdevil: 6.6.3 → 6.6.4
print-manager: 6.6.3 → 6.6.4
protonmail-bridge: 3.21.2 → 3.23.1, [31;1m742.1 KiB[0m
qqc2-breeze-style: 6.6.3 → 6.6.4, [31;1m19.3 KiB[0m
rclone: 1.73.3 → 1.73.4, [32;1m-150.0 KiB[0m
ruby3.4-logger: ∅ → 1.6.1, [31;1m39.5 KiB[0m
ruby3.4-msgpack: ∅ → 1.7.5, [31;1m507.4 KiB[0m
ruby3.4-multi_json: ∅ → 1.15.0, [31;1m61.6 KiB[0m
ruby3.4-neovim: ∅ → 0.10.0, [31;1m198.4 KiB[0m
source: [31;1m172.0 KiB[0m
spectacle: 6.6.3 → 6.6.4, [31;1m12.6 KiB[0m
stylua: 2.4.0 → 2.4.1, [32;1m-18.8 KiB[0m
systemsettings: 6.6.3 → 6.6.4
tree-sitter-c-neovim: 0.12.0 → 0.12.1
tree-sitter-lua-neovim: 0.12.0 → 0.12.1
tree-sitter-markdown-neovim: 0.12.0 → 0.12.1
tree-sitter-markdown_inline-neovim: 0.12.0 → 0.12.1
tree-sitter-query-neovim: 0.12.0 → 0.12.1
tree-sitter-vim-neovim: 0.12.0 → 0.12.1
tree-sitter-vimdoc-neovim: 0.12.0 → 0.12.1
unit-post-resume.service: ε → ∅
unit-post-resume.target: ε → ∅
unit-pre-shutdown.service: ε → ∅
unit-pre-sleep.service: ε → ∅
unit-script-post-boot-pre: ∅ → ε
unit-script-post-resume: ε → ∅
unit-script-pre-shutdown: ε → ∅
unit-script-pre-sleep: ε → ∅
unit-script-sleep-actions-pre: ∅ → ε
unit-script-sleep-actions: ∅ → ε
unit-sleep-actions.service: ∅ → ε
uv: 0.11.3 → 0.11.4, [32;1m-203.4 KiB[0m
vimplugin-luajit2.1-lualine.nvim-scm: 1-unstable-scm-1 → 2-unstable-scm-2
vimplugin-luajit2.1-luasnip: 2.4.1-1-unstable-2.4.1-1 → 2.5.0-1-unstable-2.5.0-1, [31;1m65.0 KiB[0m
vimplugin-nvim-lspconfig: 2.7.0-unstable-2026-04-03 → 2.7.0-unstable-2026-04-08
vimplugin-nvim-surround: 4.0.4-unstable-2026-04-01 → 4.0.4-unstable-2026-04-05
vimplugin-nvim-tree.lua: 1.16.0-unstable-2026-04-02 → 1.17.0-unstable-2026-04-07
xdg-desktop-portal-kde: 6.6.3 → 6.6.4
xdg-desktop-portal: 1.20.3 → 1.20.4, [31;1m51.1 KiB[0m
```

</details>