### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -53,11 +53,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776113939,
-        "narHash": "sha256-0FHBJJhVJP1p1CdEVV8yNISfz/mlhuibr6H4745pi/c=",
+        "lastModified": 1776287098,
+        "narHash": "sha256-PHnSAO0MQPGDkh+peDTDPf1HFCD7g3E916hpOyOgxIU=",
         "owner": "charmbracelet",
         "repo": "nur",
-        "rev": "8e59e2d68e057b9e30dd066db30122bf273062f4",
+        "rev": "d55b1cbb610ee1e19b1d47a81f29fc11061449d2",
         "type": "github"
       },
       "original": {
@@ -396,11 +396,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1775888245,
-        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
+        "lastModified": 1776255774,
+        "narHash": "sha256-psVTpH6PK3q1htMJpmdz1hLF5pQgEshu7gQWgKO6t6Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "13043924aaa7375ce482ebe2494338e058282925",
+        "rev": "566acc07c54dc807f91625bb286cb9b321b5f42a",
         "type": "github"
       },
       "original": {
@@ -412,11 +412,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1775710090,
-        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
+        "lastModified": 1776169885,
+        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
+        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
         "type": "github"
       },
       "original": {
@@ -432,11 +432,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1776178436,
-        "narHash": "sha256-Ev0zOGXd3z1vMYk30j3vV5J2/hMBatu0+rtoPYLhEHw=",
+        "lastModified": 1776327401,
+        "narHash": "sha256-z7NsEoQV86lxwMJMUCnphHTSltoNszJ+hMOX1KtdUJ4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7e977d11a6a6895fa8635bfd78600cb41c5e6533",
+        "rev": "305f961280a701b0aff80cad4b2035725ee5935c",
         "type": "github"
       },
       "original": {
@@ -571,11 +571,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1776184243,
-        "narHash": "sha256-DR6YpiFVA5sCrB24UPs9ZMhPZ5om6Nck0QtLlyIOl2E=",
+        "lastModified": 1776328039,
+        "narHash": "sha256-Hr1Hmekfq7M0A1kUdnOA0WTm/qzxc0ayPe0z2savmQk=",
         "owner": "oraios",
         "repo": "serena",
-        "rev": "94bd2e52b6c2be4f869d3b19484af77c00aa7e43",
+        "rev": "7a0d142185ca2b192d2c71a707fd9ea062fa3a92",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated update of `flake.lock` inputs.

All hosts built successfully against this lock file.
Merging will trigger `autodeploy.yaml`, which publishes store paths for pickup by `nixos-autodeploy`.

## Package changes

**Added: 4 | Removed: 9 | Changed: 57**

<details>
<summary>Full diff</summary>

```
busted-luarocks-config.lua: ∅ → ε
claude-code: 2.1.97 → 2.1.104, [31;1m187.5 KiB[0m
cmake: ∅ → 4.1.2, [31;1m61.0 MiB[0m
crush: 0.57.0 → 0.58.0, [31;1m29.2 KiB[0m
curl: [31;1m1.1 MiB[0m
die: ∅ → ε
firefox-unwrapped: [31;1m8.4 KiB[0m
flatpak: 1.16.4 → 1.16.6
fwupd: 2.0.19 → 2.1.1, [31;1m548.2 KiB[0m
gotools: 0.34.0 → 0.44.0, [32;1m-9.9 MiB[0m
initrd-linux: 6.18.21 → 6.18.22, [31;1m13.8 MiB[0m
install-shell: ∅ → ε, [31;1m11.9 KiB[0m
linux: 6.18.21 → 6.18.22, [32;1m-37.4 KiB[0m
lua-language-server: 3.18.0 → 3.18.1
luajit2.1-busted: ∅ → 2.3.0-1, [31;1m201.2 KiB[0m
luajit2.1-coxpcall: ∅ → 1.17.0-1, [31;1m31.7 KiB[0m
luajit2.1-dkjson: ∅ → 2.8-2, [31;1m34.8 KiB[0m
luajit2.1-inspect: ∅ → 3.1.3-0, [31;1m21.6 KiB[0m
luajit2.1-lua-term: ∅ → 0.8-1, [31;1m31.7 KiB[0m
luajit2.1-lua_cliargs: ∅ → 3.0.2-1, [31;1m51.1 KiB[0m
luajit2.1-luafilesystem: ∅ → 1.9.0-1, [31;1m77.9 KiB[0m
luajit2.1-luasystem: ∅ → 0.7.0-1, [31;1m78.3 KiB[0m
luajit2.1-luv: ∅ → 1.51.0-2, [31;1m254.3 KiB[0m
luajit2.1-mediator_lua: ∅ → 1.1.2-0, [31;1m13.8 KiB[0m
luajit2.1-penlight: ∅ → 1.15.0-1, [31;1m1.8 MiB[0m
luajit: [31;1m25.3 KiB[0m
luarocks_bootstrap: ∅ → 3.13.0, [31;1m800.9 KiB[0m
make-shell-wrapper: ∅ → ε, [31;1m10.4 KiB[0m
mupdf: 1.27.0 → 1.27.2, [31;1m12.0 KiB[0m
nix-cmd: 2.31.4 → 2.34.6, [31;1m93.5 KiB[0m
nix-expr: 2.31.4 → 2.34.6, [31;1m520.9 KiB[0m
nix-fetchers: 2.31.4 → 2.34.6, [31;1m170.1 KiB[0m
nix-flake: 2.31.4 → 2.34.6, [31;1m25.3 KiB[0m
nix-main: 2.31.4 → 2.34.6, [31;1m23.0 KiB[0m
nix-manual: 2.31.4 → 2.34.6, [31;1m2.7 MiB[0m
nix-nswrapper: ∅ → 2.34.6, [31;1m131.8 KiB[0m
nix-store: 2.31.4 → 2.34.6, [31;1m815.0 KiB[0m
nix-util: 2.31.4 → 2.34.6, [31;1m446.2 KiB[0m
nix: 2.31.4 → 2.34.6, [31;1m383.6 KiB[0m
nixos-manual: [31;1m106.0 KiB[0m
nixos-system-kushtaka: 26.05.20260411.1304392 → 26.05.20260415.566acc0, [31;1m176.5 KiB[0m
nixos-system-snallygaster: 26.05.20260411.1304392 → 26.05.20260415.566acc0, [31;1m176.5 KiB[0m
nixos-system-wendigo: 26.05.20260411.1304392 → 26.05.20260415.566acc0, [31;1m176.5 KiB[0m
node_exporter: 1.11.0 → 1.11.1
nss: 3.122 → 3.122.1
oraios-pywebview: 6.2 → ∅, [32;1m-2.1 MiB[0m
parted: 3.6 → 3.7, [31;1m130.0 KiB[0m
pipewire-ladspa: ∅ → ε
prismlauncher-unwrapped: 11.0.0 → 11.0.1
prismlauncher: 11.0.0 → 11.0.1
python-multipart: 0.0.22 → 0.0.26, [31;1m9.4 KiB[0m
pywebview: ∅ → 6.2, [31;1m2.2 MiB[0m
rhash: ∅ → 1.4.4, [31;1m366.5 KiB[0m
ruff: 0.15.9 → 0.15.10, [31;1m32.5 KiB[0m
signal-desktop: 8.6.0 → 8.6.1, [32;1m-74.6 KiB[0m
source: [31;1m1.0 MiB[0m
thermald: 2.5.10 → 2.5.11, [32;1m-26.2 KiB[0m
unit-modprobe: ∅ → .service
unit-network-setup.service: ∅ → ε
unit-network.target: ε → ∅
unit-networking-scripted.target: ε → ∅
unit-script-network-local-commands: ε → ∅
unit-script-network-setup: ∅ → ε
unit-sshd-vsock.socket: ∅ → ε
unit-sshd-vsock: ∅ → .service
unit-systemd-udev-settle.service: ε → ∅
wrap-lua: ∅ → ε
x86_energy_perf_policy: 6.18.21 → 6.18.22
xorg-server: 21.1.21 → 21.1.22, [31;1m12.0 KiB[0m
xwayland: 24.1.9 → 24.1.10
```

</details>