### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -53,11 +53,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776287098,
-        "narHash": "sha256-PHnSAO0MQPGDkh+peDTDPf1HFCD7g3E916hpOyOgxIU=",
+        "lastModified": 1776444935,
+        "narHash": "sha256-8sRqf6Tps3HA0lqiT9336feBElFbdQ45Xxy9DOT3J14=",
         "owner": "charmbracelet",
         "repo": "nur",
-        "rev": "d55b1cbb610ee1e19b1d47a81f29fc11061449d2",
+        "rev": "4ff778843c475d1c404899ba2cfcf99a6499d49c",
         "type": "github"
       },
       "original": {
@@ -254,11 +254,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776184304,
-        "narHash": "sha256-No6QGBmIv5ChiwKCcbkxjdEQ/RO2ZS1gD7SFy6EZ7rc=",
+        "lastModified": 1776562531,
+        "narHash": "sha256-Lh5Ns9DI67E+lSMOCGK0S+mFPy0mz0yOGiJTUXiR9JI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3c7524c68348ef79ce48308e0978611a050089b2",
+        "rev": "5b56ad02dc643808b8af6d5f3ff179e2ce9593f4",
         "type": "github"
       },
       "original": {
@@ -293,11 +293,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775970782,
-        "narHash": "sha256-7jt9Vpm48Yy5yAWigYpde+HxtYEpEuyzIQJF4VYehhk=",
+        "lastModified": 1776575850,
+        "narHash": "sha256-28Gqz0GDpGsBv8GtAn2dywEQRr+CtTDsD5J7VD6icBE=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "bedba5989b04614fc598af9633033b95a937933f",
+        "rev": "3b9653a107c736222b5ae0d4036dd3b885219065",
         "type": "github"
       },
       "original": {
@@ -396,11 +396,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1776255774,
-        "narHash": "sha256-psVTpH6PK3q1htMJpmdz1hLF5pQgEshu7gQWgKO6t6Y=",
+        "lastModified": 1776329215,
+        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "566acc07c54dc807f91625bb286cb9b321b5f42a",
+        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
         "type": "github"
       },
       "original": {
@@ -432,11 +432,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1776327401,
-        "narHash": "sha256-z7NsEoQV86lxwMJMUCnphHTSltoNszJ+hMOX1KtdUJ4=",
+        "lastModified": 1776582936,
+        "narHash": "sha256-EtT3GYHIylg03SML7Gh6FC9jEUGeZJROYywOl4vjLsU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "305f961280a701b0aff80cad4b2035725ee5935c",
+        "rev": "4473aaf861eb94d480e3c90e4b069ce1d02b44e8",
         "type": "github"
       },
       "original": {
@@ -571,11 +571,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1776328039,
-        "narHash": "sha256-Hr1Hmekfq7M0A1kUdnOA0WTm/qzxc0ayPe0z2savmQk=",
+        "lastModified": 1776538134,
+        "narHash": "sha256-TTm7u1ertgltZCTA5IMbA/yG28tnSQdjZvYR7LeyRRM=",
         "owner": "oraios",
         "repo": "serena",
-        "rev": "7a0d142185ca2b192d2c71a707fd9ea062fa3a92",
+        "rev": "11dfdbf8c5aedad5d5ef975112f1360b00e79c86",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated update of `flake.lock` inputs.

All hosts built successfully against this lock file.
Merging will trigger `autodeploy.yaml`, which publishes store paths for pickup by `nixos-autodeploy`.

## Package changes

**Added: 0
0 | Removed: 0
0 | Changed: **

<details>
<summary>Full diff</summary>

```
claude-code: 2.1.104 → 2.1.107, [31;1m108.4 KiB[0m
crush: 0.58.0 → 0.60.0, [31;1m917.1 KiB[0m
libutempter: 1.2.1 → 1.2.3
mesa: 26.0.4 → 26.0.5
mesa: 26.0.4 → 26.0.5, [31;1m15.1 KiB[0m
nixos-system-kushtaka: 26.05.20260415.566acc0 → 26.05.20260416.b86751b
nixos-system-snallygaster: 26.05.20260415.566acc0 → 26.05.20260416.b86751b
nixos-system-wendigo: 26.05.20260415.566acc0 → 26.05.20260416.b86751b
prismlauncher-unwrapped: 11.0.1 → 11.0.2
prismlauncher: 11.0.1 → 11.0.2
python3.13-sentry-sdk: 2.54.0 → 2.58.0, [31;1m350.2 KiB[0m
serena-agent: [31;1m16.1 KiB[0m
source: [31;1m42.4 KiB[0m
vim-full: 9.2.0106 → 9.2.0340, [31;1m99.2 KiB[0m
```

</details>