### PR TITLE
Implement automatic printer discovery feature

### DIFF
--- a/nixos/profiles/laptop/default.nix
+++ b/nixos/profiles/laptop/default.nix
@@ -13,8 +13,25 @@
   hardware.bluetooth.enable = true;
   services.blueman.enable = true;
 
-  # Printing — laptop hosts run CUPS locally
+  # Printing — both printers support IPP Everywhere (driverless IPP/Mopria);
+  # no host-side driver packages are needed.
   services.printing.enable = true;
+
+  # mDNS/Bonjour — auto-discovers network printers advertising via DNS-SD
+  services.avahi = {
+    enable = true;
+    nssmdns4 = true; # allows resolving .local hostnames for printer discovery
+    openFirewall = true; # opens UDP 5353 for mDNS; intentional for LAN printer discovery
+  };
+
+  # auto-creates CUPS queues for discovered network printers (no manual lpadmin needed)
+  services.printing.browsed.enable = true;
+
+  # cups-browsed has a race condition on first boot: it may start before Avahi
+  # has fully resolved .local hostnames, leaving queues with no destination.
+  # Explicitly ordering it after avahi-daemon.service prevents this.
+  systemd.services.cups-browsed.after = ["avahi-daemon.service"];
+  systemd.services.cups-browsed.requires = ["avahi-daemon.service"];
 
   #### Desktop-related system packages ####
   environment.systemPackages = with pkgs; [


### PR DESCRIPTION
This pull request improves network printer discovery and setup on laptops by enabling mDNS/Bonjour support and automating printer queue creation. It also addresses a race condition between the printer discovery service and Avahi on first boot.

**Printer discovery and setup:**

* Enabled `services.avahi` with mDNS/Bonjour to allow automatic discovery of network printers via DNS-SD, including opening the firewall for UDP 5353 traffic.
* Enabled `services.printing.browsed` to auto-create CUPS queues for discovered network printers, eliminating the need for manual printer setup.

**Service ordering improvements:**

* Configured `systemd.services.cups-browsed` to start after and require `avahi-daemon.service`, preventing a race condition where printer queues could be created without valid destinations.