### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -53,11 +53,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776778594,
-        "narHash": "sha256-gUjPK5P90/kBOMoFeDhUMfoGJTbgJLF2QVtSJGNpgzk=",
+        "lastModified": 1777062504,
+        "narHash": "sha256-AqExE4bBax09B4jM0xDMGO+ZoDA6it/Yca288ROKrV0=",
         "owner": "charmbracelet",
         "repo": "nur",
-        "rev": "484c1955e5b41c9f5cb9943fe7b174948b4d1eb6",
+        "rev": "d65dd4f83427f43e8d9b3446ae12d9f6e334a487",
         "type": "github"
       },
       "original": {
@@ -254,11 +254,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776777932,
-        "narHash": "sha256-0R3Yow/NzSeVGUke5tL7CCkqmss4Vmi6BbV6idHzq/8=",
+        "lastModified": 1777086106,
+        "narHash": "sha256-hlNpIN18pw3xo34Lsrp6vAMUPn0aB/zFBqL0QXI1Pmk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5d5640599a0050b994330328b9fd45709c909720",
+        "rev": "5826802354a74af18540aef0b01bc1320f82cc17",
         "type": "github"
       },
       "original": {
@@ -332,11 +332,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1776830795,
-        "narHash": "sha256-PAfvLwuHc1VOvsLcpk6+HDKgMEibvZjCNvbM1BJOA7o=",
+        "lastModified": 1776983936,
+        "narHash": "sha256-ZOQyNqSvJ8UdrrqU1p7vaFcdL53idK+LOM8oRWEWh6o=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "72674a6b5599e844c045ae7449ba91f803d44ebc",
+        "rev": "2096f3f411ce46e88a79ae4eafcfc9df8ed41c61",
         "type": "github"
       },
       "original": {
@@ -396,11 +396,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1776329215,
-        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
+        "lastModified": 1776949667,
+        "narHash": "sha256-GMSVw35Q+294GlrTUKlx087E31z7KurReQ1YHSKp5iw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
+        "rev": "01fbdeef22b76df85ea168fbfe1bfd9e63681b30",
         "type": "github"
       },
       "original": {
@@ -412,11 +412,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1776548001,
-        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
+        "lastModified": 1776877367,
+        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
+        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
         "type": "github"
       },
       "original": {
@@ -432,11 +432,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1776845162,
-        "narHash": "sha256-mhPzo1pylcHTWoqOHRaGaGE3DgkrjDi5E9LTJzEMu88=",
+        "lastModified": 1777103209,
+        "narHash": "sha256-f7lpFMGpJ07txOzH8+cnwX4UphMHWAL/jwZ9Auu0XFE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "01c71cab933d89869cd0a29fd3c32fc693f322f2",
+        "rev": "855aac885db01ac51bedee347a34c4522e2bd4e2",
         "type": "github"
       },
       "original": {
@@ -571,11 +571,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1776815137,
-        "narHash": "sha256-BXt76W1hdnvJiyXtnq8AwxFA0Tr4jBG1bBdKNZbRwq8=",
+        "lastModified": 1777056163,
+        "narHash": "sha256-LhBfjRmM2R7/JOkJJvyWX/oSngSgpUuZOlDJdilwUxY=",
         "owner": "oraios",
         "repo": "serena",
-        "rev": "110ddffc45bfd360b9f56133f1dffe27990ce8c7",
+        "rev": "7a8b5fb212eecbd5bd1d52c77a5086aee6650cf3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated update of `flake.lock` inputs.

All hosts built successfully against this lock file.
Merging will trigger `autodeploy.yaml`, which publishes store paths for pickup by `nixos-autodeploy`.

## Package changes

**Added: 10 | Removed: 7 | Changed: 297**

<details>
<summary>Full diff</summary>

```
1password-cli: 2.33.1 → 2.34.0, [31;1m72.0 KiB[0m
X-Restart-Triggers-dbus: ∅ → ε
ada: 3.4.3 → 3.4.4
akonadi-calendar: 25.12.3 → 26.04.0, [32;1m-34.2 KiB[0m
akonadi-contacts: 25.12.3 → 26.04.0
akonadi-mime: 25.12.3 → 26.04.0, [31;1m14.2 KiB[0m
akonadi-search: 25.12.3 → 26.04.0, [32;1m-113.5 KiB[0m
akonadi: 25.12.3 → 26.04.0, [31;1m107.2 KiB[0m
ark: 25.12.3 → 26.04.0, [31;1m26.9 KiB[0m
aspell: 0.60.8.1 → 0.60.8.2, [31;1m31.8 KiB[0m
atuin: 18.13.6 → 18.15.2, [31;1m3.4 MiB[0m
baloo-widgets: 25.12.3 → 26.04.0, [31;1m10.6 KiB[0m
bluez: 5.84 → 5.86, [31;1m126.5 KiB[0m
bluez: 5.84 → 5.86, [31;1m250.0 KiB[0m
bubblewrap: 0.11.0 → 0.11.1
busted-luarocks-config.lua: ε → ∅
c-dvar: ∅ → 1.2.0, [31;1m118.7 KiB[0m
c-ini: ∅ → 1.1.0, [31;1m59.5 KiB[0m
c-rbtree: ∅ → 3.2.0, [31;1m56.9 KiB[0m
c-shquote: ∅ → 1.1.0, [31;1m37.6 KiB[0m
c-utf8: ∅ → 1.1.0, [31;1m20.6 KiB[0m
claude-code: 2.1.107 → 2.1.112, [31;1m32.9 KiB[0m
cmake: 4.1.2 → ∅, [32;1m-61.0 MiB[0m
crush: 0.61.1 → 0.62.1, [31;1m817.1 KiB[0m
cryptsetup: 2.8.4 → 2.8.6, [31;1m16.5 KiB[0m
cryptsetup: 2.8.4 → 2.8.6, [31;1m33.0 KiB[0m
curl: 8.18.0 → 8.19.0, [32;1m-1.1 MiB[0m
dash: 0.5.13.1 → 0.5.13.2
dbus-broker: ∅ → 37, [31;1m413.4 KiB[0m
die: ε → ∅
docker-containerd: [31;1m8.1 KiB[0m
dolphin-plugins: 25.12.3 → 26.04.0
dolphin: 25.12.3 → 26.04.0, [31;1m145.1 KiB[0m
editorconfig-core-c: 0.12.9 → 0.12.11
electron-unwrapped: ∅ → 39.8.7, [31;1m295.9 MiB[0m
electron: ∅ → 39.8.7
elisa: 25.12.3 → 26.04.0, [31;1m342.2 KiB[0m
ell: 0.82 → 0.83
ethtool: 6.15 → 6.19, [31;1m12.9 KiB[0m
ethtool: 6.15 → 6.19, [31;1m25.9 KiB[0m
expat: 2.7.4 → 2.7.5
fd: [31;1m38.8 KiB[0m
ffmpegthumbs: 25.12.3 → 26.04.0
firefox-unwrapped: 149.0.2 → 150.0, [31;1m1.6 MiB[0m
firefox: 149.0.2 → 150.0, [31;1m8.2 KiB[0m
freeglut-mupdf: 3.0.0-r13ae6aa2c2f9a7b4266fc2e6116c876237f40477 → 3.0.0-rd5e2256d571b3ef66fb60716c99e35e9d3e570a2
freetype: 2.13.3 → 2.14.2, [31;1m110.0 KiB[0m
gawk: 5.3.2 → 5.4.0, [31;1m987.4 KiB[0m
getent-glibc: 2.42-51 → 2.42-61
gettext: 0.26 → 1.0, [31;1m5.0 MiB[0m
gh: 2.89.0 → 2.91.0, [32;1m-49.6 KiB[0m
glibc-locales: 2.42-51 → 2.42-61
glibc-multi: 2.42-51 → 2.42-61
glibc: 2.42-51 → 2.42-61
gnum4: 1.4.20 → 1.4.21, [31;1m22.0 KiB[0m
gnum4: 1.4.20 → 1.4.21, [31;1m44.0 KiB[0m
go: 1.26.1 → 1.26.2, [31;1m30.1 KiB[0m
gotools: [31;1m12.0 KiB[0m
gpm-unstable: [32;1m-443.3 KiB[0m
grantleetheme: 25.12.3 → 26.04.0
groff: 1.23.0 → 1.24.1, [31;1m189.1 KiB[0m
gsm: 1.0.23 → 1.0.24
gst-plugins-bad: 1.26.5 → 1.26.11
gst-plugins-base: 1.26.5 → 1.26.11, [31;1m12.5 KiB[0m
gst-plugins-base: 1.26.5 → 1.26.11, [31;1m28.9 KiB[0m
gst-plugins-good: 1.26.5 → 1.26.11, [31;1m8.7 KiB[0m
gstreamer: 1.26.5 → 1.26.11
gstreamer: 1.26.5 → 1.26.11, [31;1m16.7 KiB[0m
gtk+3: 3.24.51 → 3.24.52, [31;1m815.4 KiB[0m
gwenview: 25.12.3 → 26.04.0, [31;1m8.8 KiB[0m
hm_.configmozillafirefoxdefault.keep: ∅ → ε
hm_.configmozillafirefoxdefaultuser.js: ∅ → ε
hm_.configmozillafirefoxprofiles.ini: ∅ → ε
hm_.mozillafirefoxdefault.keep: ε → ∅
hm_.mozillafirefoxdefaultuser.js: ε → ∅
hm_.mozillafirefoxprofiles.ini: ε → ∅
hm_kittydiff.conf: ∅ → ε
home-configuration-reference: [31;1m20.4 KiB[0m
hwdata: 0.405 → 0.406, [31;1m78.9 KiB[0m
hwdb.bin: [31;1m110.9 KiB[0m
imagemagick: 7.1.2-17 → 7.1.2-19, [31;1m31.4 KiB[0m
imath: 3.2.1 → 3.2.2
initrd-linux: 6.18.22 → 6.18.24, [31;1m666.5 KiB[0m
initrd-linux: 6.18.22 → 6.18.24, [31;1m672.0 KiB[0m
initrd-linux: 6.18.22 → 6.18.24, [31;1m674.6 KiB[0m
install-shell: ε → ∅, [32;1m-11.9 KiB[0m
iptables: 1.8.12 → 1.8.13
jasper: 4.2.8 → 4.2.9
jjui: 0.10.2 → 0.10.3, [31;1m2.8 MiB[0m
just: 1.49.0 → 1.50.0
kaccounts-integration: 25.12.3 → 26.04.0
kate: 25.12.3 → 26.04.0, [31;1m317.8 KiB[0m
kcalutils: 25.12.3 → 26.04.0
kcontacts: [31;1m12.5 KiB[0m
kde-gtk-config: [31;1m88.0 KiB[0m
kde-inotify-survey: 25.12.3 → 26.04.0
kdegraphics-mobipocket: 25.12.3 → 26.04.0
kdegraphics-thumbnailers: 25.12.3 → 26.04.0
kdepim-runtime: 25.12.3 → 26.04.0, [31;1m93.4 KiB[0m
kdeplasma-addons: [32;1m-29.2 KiB[0m
kexec-tools: [31;1m242.4 KiB[0m
khelpcenter: 25.12.3 → 26.04.0
kidentitymanagement: 25.12.3 → 26.04.0
kimap: 25.12.3 → 26.04.0, [32;1m-173.4 KiB[0m
kio-admin: 25.12.3 → 26.04.0
kio-extras: 25.12.3 → 26.04.0, [31;1m9.3 KiB[0m
kio: [31;1m8.9 KiB[0m
kirigami-addons: [32;1m-18.3 KiB[0m
kldap: 25.12.3 → 26.04.0
kmailtransport: 25.12.3 → 26.04.0
kmbox: 25.12.3 → 26.04.0
kmime: 25.12.3 → 26.04.0
konsole: 25.12.3 → 26.04.0, [31;1m400.4 KiB[0m
kpimtextedit: 25.12.3 → 26.04.0, [31;1m10.6 KiB[0m
kquickimageeditor: 0.6.0 → 0.6.1
kscreen: [32;1m-12.9 KiB[0m
ksmtp: 25.12.3 → 26.04.0
ktexttemplate: [32;1m-15.1 KiB[0m
kunifiedpush: 25.12.3 → 26.04.0, [31;1m12.1 KiB[0m
kwallet: [32;1m-11.5 KiB[0m
kwalletmanager: 25.12.3 → 26.04.0, [32;1m-38.8 KiB[0m
kwin: [32;1m-9.5 KiB[0m
ldns: 1.8.4 → 1.9.0
leptonica: ∅ → 1.87.0, [31;1m3.8 MiB[0m
lerc: 4.0.0 → 4.1.0, [32;1m-24.7 KiB[0m
libadwaita: 1.8.4 → 1.8.5.1
libapparmor: 4.1.3 → 4.1.7, [31;1m8.2 KiB[0m
libarchive: 3.8.4 → 3.8.6
libavif: 1.3.0 → 1.4.1, [31;1m107.6 KiB[0m
libcamera: [32;1m-220.8 KiB[0m
libcamera: [32;1m-446.8 KiB[0m
libcap-ng: 0.9 → 0.9.2, [31;1m82.2 KiB[0m
libde265: 1.0.16 → 1.0.18, [32;1m-356.3 KiB[0m
libevdev: 1.13.4 → 1.13.6
libfontenc: 1.1.8 → 1.1.9, [31;1m101.7 KiB[0m
libfyaml: 0.9.5 → 0.9.6
libgpg-error: 1.58 → 1.59
libgpg-error: 1.58 → 1.59, [31;1m8.7 KiB[0m
libgravatar: 25.12.3 → 26.04.0
libipt: 2.1.2 → 2.2
libjpeg-turbo: 3.1.3 → 3.1.4, [31;1m9.1 KiB[0m
libkdcraw: 25.12.3 → 26.04.0
libkdepim: 25.12.3 → 26.04.0
libkexiv2: 25.12.3 → 26.04.0
libkgapi: 25.12.3 → 26.04.0
libkleo: 25.12.3 → 26.04.0, [31;1m113.5 KiB[0m
libldac-dec: 0.0.2-unstable-2024-11-12 → ∅, [32;1m-51.5 KiB[0m
libldac-dec: 0.0.2-unstable-2024-11-12 → ∅, [32;1m-93.7 KiB[0m
libluv: 1.51.0-2 → 1.52.1-0
libmpc: 1.3.1 → 1.4.0, [31;1m20.1 KiB[0m
libnetfilter_conntrack: 1.1.0 → 1.1.1
libopenmpt: 0.8.4 → 0.8.6
libpciaccess: 0.18.1 → 0.19
libpng-apng: 1.6.55 → 1.6.56
libpng: ∅ → 1.6.56, [31;1m255.8 KiB[0m
libqmi: 1.36.0 → 1.38.0, [31;1m121.1 MiB[0m
libqmi: 1.36.0 → 1.38.0, [31;1m60.5 MiB[0m
libraw: 0.21.5b → 0.22.0, [31;1m132.1 KiB[0m
libsodium: 1.0.21-unstable-2026-02-11 → 1.0.21-unstable-2026-03-29
libsrtp: 2.7.0 → 2.8.0
libssh: 0.11.3 → 0.12.0, [31;1m150.2 KiB[0m
libssh: 0.11.3 → 0.12.0, [31;1m81.1 KiB[0m
libultrahdr: ∅ → 1.4.0, [31;1m2.9 MiB[0m
libunistring: 1.4.1 → 1.4.2
libuv: 1.52.0 → 1.52.1
libxfont_2: [32;1m-105.2 KiB[0m
lilv: 0.26.2 → 0.26.4
linux: 6.18.22 → 6.18.24, [32;1m-75.7 KiB[0m
lnav: 0.13.2 → 0.14.0, [31;1m11.3 MiB[0m
lsof: 4.99.5 → 4.99.6
luajit2.1-busted: 2.3.0-1 → ∅, [32;1m-201.2 KiB[0m
luajit2.1-coxpcall: 1.17.0-1 → ∅, [32;1m-31.7 KiB[0m
luajit2.1-dkjson: 2.8-2 → ∅, [32;1m-34.8 KiB[0m
luajit2.1-inspect: 3.1.3-0 → ∅, [32;1m-21.6 KiB[0m
luajit2.1-lua-term: 0.8-1 → ∅, [32;1m-31.7 KiB[0m
luajit2.1-lua_cliargs: 3.0.2-1 → ∅, [32;1m-51.1 KiB[0m
luajit2.1-luafilesystem: 1.9.0-1 → ∅, [32;1m-77.9 KiB[0m
luajit2.1-luasystem: 0.7.0-1 → ∅, [32;1m-78.3 KiB[0m
luajit2.1-luv: 1.51.0-2 → ∅, [32;1m-254.3 KiB[0m
luajit2.1-mediator_lua: 1.1.2-0 → ∅, [32;1m-13.8 KiB[0m
luajit2.1-penlight: 1.15.0-1 → ∅, [32;1m-1.8 MiB[0m
luajit: [32;1m-25.3 KiB[0m
luarocks_bootstrap: 3.13.0 → ∅, [32;1m-800.9 KiB[0m
make-shell-wrapper: ε → ∅, [32;1m-10.4 KiB[0m
mbedtls: [32;1m-18.0 KiB[0m
mcp: 1.26.0 → 1.27.0, [32;1m-71.7 KiB[0m
mesa-libgbm: 25.1.0 → 26.0.3
messagelib: 25.12.3 → 26.04.0, [31;1m72.3 KiB[0m
mise: [32;1m-28.0 KiB[0m
modemmanager-qt: [31;1m8.0 KiB[0m
neon: 0.36.0 → 0.37.1, [31;1m53.6 KiB[0m
nghttp2: 1.67.1 → 1.68.1
nghttp3: 1.14.0 → 1.15.0
ngtcp2: 1.19.0 → 1.22.0
nh-unwrapped: 4.3.0 → 4.3.1, [31;1m557.8 KiB[0m
nh: 4.3.0 → 4.3.1
nixos-manual: [31;1m121.5 KiB[0m
nixos-system-kushtaka: 26.05.20260416.b86751b → 26.05.20260423.01fbdee
nixos-system-snallygaster: 26.05.20260416.b86751b → 26.05.20260423.01fbdee
nixos-system-wendigo: 26.05.20260416.b86751b → 26.05.20260423.01fbdee
nodejs-slim: 24.14.0 → 24.14.1, [31;1m625.3 KiB[0m
nodejs: 24.14.0 → 24.14.1
nss: 3.122.1 → 3.123, [31;1m9.1 KiB[0m
okular: 25.12.3 → 26.04.0, [32;1m-87.1 KiB[0m
openapv: 0.2.1.1 → 0.2.1.2
openblas: 0.3.31 → 0.3.32, [31;1m3.6 MiB[0m
openexr: 3.3.5 → 3.3.8
openjdk: [31;1m9.4 KiB[0m
openldap: 2.6.9 → 2.6.13, [31;1m8.2 KiB[0m
openssh: 10.2p1 → 10.3p1, [32;1m-1.0 MiB[0m
ostree: 2025.7 → 2026.1
p11-kit: 0.26.1 → 0.26.2
pimcommon: 25.12.3 → 26.04.0, [32;1m-105.2 KiB[0m
pipewire: 1.6.2 → 1.6.3, [32;1m-133.9 KiB[0m
pipewire: 1.6.2 → 1.6.3, [32;1m-63.8 KiB[0m
plasma-desktop: [32;1m-33.7 KiB[0m
plasma-nm: [31;1m28.3 KiB[0m
plasma-sdk: [32;1m-11.4 KiB[0m
plasma-workspace: [32;1m-8.3 KiB[0m
polkit-qt: 1-0.200.0 → 1-0.201.1
prismlauncher-unwrapped: [32;1m-23.0 KiB[0m
protobuf: 34.0 → 34.1
protonmail-bridge: 3.23.1 → 3.24.1, [31;1m1.9 MiB[0m
publicsuffix-list: 0-unstable-2026-03-02 → 0-unstable-2026-03-26
purpose: [32;1m-11.5 KiB[0m
pyright-internal: 1.1.408 → 1.1.409, [31;1m253.9 KiB[0m
pyright: 1.1.408 → 1.1.409, [31;1m152.7 KiB[0m
python-dotenv: 1.2.1 → 1.2.2
python3.13-gst-python: 1.26.0 → 1.26.11, [31;1m40.9 KiB[0m
python3.13-psutil: 7.2.1 → 7.2.2, [31;1m17.7 KiB[0m
python3: [31;1m30.1 MiB[0m
qrca: 25.12.3 → 26.04.0
qt5compat: 6.10.2 → 6.11.0
qtbase: 6.10.2, 6.10.2-only-plugins → 6.11.0, 6.11.0-only-plugins, [31;1m475.0 KiB[0m
qtdeclarative: 6.10.2 → 6.11.0, [31;1m10.7 MiB[0m
qtimageformats: 6.10.2 → 6.11.0
qtlocation: 6.10.2 → 6.11.0, [31;1m28.0 KiB[0m
qtmultimedia: 6.10.2 → 6.11.0, [31;1m195.0 KiB[0m
qtnetworkauth: 6.10.2 → 6.11.0
qtpositioning: 6.10.2 → 6.11.0, [31;1m12.3 KiB[0m
qtquick3d: 6.10.2 → 6.11.0, [31;1m3.8 MiB[0m
qtsensors: 6.10.2 → 6.11.0, [31;1m14.4 KiB[0m
qtserialport: 6.10.2 → 6.11.0
qtshadertools: 6.10.2 → 6.11.0, [31;1m492.3 KiB[0m
qtspeech: 6.10.2 → 6.11.0, [31;1m38.5 KiB[0m
qtsvg: 6.10.2 → 6.11.0, [31;1m38.1 KiB[0m
qttools: 6.10.2 → 6.11.0, [31;1m3.3 MiB[0m
qttranslations: 6.10.2 → 6.11.0, [31;1m12.1 KiB[0m
qtvirtualkeyboard: 6.10.2 → 6.11.0, [31;1m48.2 KiB[0m
qtwayland: 6.10.2 → 6.11.0, [31;1m93.5 KiB[0m
qtwebchannel: 6.10.2 → 6.11.0, [31;1m21.5 KiB[0m
qtwebengine: 6.10.2 → 6.11.0, [32;1m-7.2 MiB[0m
qtwebsockets: 6.10.2 → 6.11.0
qtwebview: 6.10.2 → 6.11.0, [32;1m-20.0 KiB[0m
rclone: 1.73.4 → 1.73.5
rhash: 1.4.4 → ∅, [32;1m-366.5 KiB[0m
ruby: 3.4.8 → 3.4.9, [31;1m10.7 KiB[0m
ruff: 0.15.10 → 0.15.11, [31;1m107.4 KiB[0m
s2n-tls: 1.6.4 → 1.7.2, [32;1m-54.3 KiB[0m
samba: 4.22.7 → 4.23.5, [31;1m411.9 KiB[0m
sbin: ε → ∅
sdl2-compat: 2.32.64 → 2.32.66
security-wrapper-dbus-daemon-launch-helper-x86_64-unknown-linux: ε → ∅, [32;1m-70.0 KiB[0m
serd: 0.32.6 → 0.32.8
serena-agent: [31;1m87.8 KiB[0m
signal-desktop: [31;1m22.4 KiB[0m
signond: [32;1m-9.4 KiB[0m
simdjson: 4.3.1 → 4.6.0, [31;1m116.5 KiB[0m
simdutf: 8.0.0 → 8.1.0, [31;1m28.7 KiB[0m
solid: [31;1m20.1 KiB[0m
soundtouch: 2.4.0 → 2.4.1
source: [31;1m658.8 KiB[0m
spectacle: [32;1m-8.5 KiB[0m
sqlite: [31;1m16.6 KiB[0m
sratom: 0.6.20 → 0.6.22
steam-run: [31;1m2.3 MiB[0m
steam: [31;1m2.3 MiB[0m
strongswan: 6.0.5 → 6.0.6
subversion-client: [32;1m-74.6 KiB[0m
switch-to-configuration: [31;1m44.7 KiB[0m
system: [31;1m35.1 KiB[0m
systemd-minimal-libs: 259.3 → 260.1, [31;1m842.5 KiB[0m
systemd-minimal: 259.3 → 260.1, [31;1m2.1 MiB[0m
systemd: 259.3 → 260.1, [31;1m3.5 MiB[0m
systemd: 259.3 → 260.1, [31;1m7.5 MiB[0m
taglib: 2.1.1 → 2.2.1, [31;1m379.9 KiB[0m
tesseract: ∅ → 5.5.2, [31;1m4.5 MiB[0m
time: 1.9 → 1.10
tree-sitter: 0.25.10 → 0.26.8, [31;1m1.7 MiB[0m
unit-autovt: .service → ∅
unit-blueman-applet.service: ∅ → ε
unit-dbus-broker.service: ∅ → ε
unixobcd: 2.3.12 → ∅, [32;1m-1.1 MiB[0m
unixodbc: ∅ → 2.3.14, [31;1m1005.0 KiB[0m
usage: 3.2.0 → 3.2.1
util-linux-minimal: 2.41.3 → 2.42, [31;1m902.6 KiB[0m
util-linux: 2.41.3 → 2.42, [31;1m1.5 MiB[0m
vimplugin-ale: 4.0.0-unstable-2026-04-01 → 4.0.0-unstable-2026-04-15, [31;1m11.2 KiB[0m
vimplugin-fzf.vim: 0-unstable-2026-02-02 → 0-unstable-2026-04-10
vimplugin-indent-blankline.nvim: 3.9.1-unstable-2026-02-17 → 3.9.1
vimplugin-luajit2.1-lualine.nvim-scm: 2-unstable-scm-2 → 3-unstable-scm-3
vimplugin-luajit2.1-telescope.nvim-scm: [32;1m-12.6 KiB[0m
vimplugin-nvim-lspconfig: 2.7.0-unstable-2026-04-08 → 2.8.0
vimplugin-nvim-tree.lua: 1.17.0-unstable-2026-04-07 → 1.17.0-unstable-2026-04-16
vimplugin-todo-comments.nvim: 1.5.0-unstable-2025-11-10 → 1.5.0
vimplugin-vim-airline: 0.11-unstable-2026-03-11 → 0.11-unstable-2026-04-13, [31;1m11.7 KiB[0m
wrap-lua: ε → ∅
x86_energy_perf_policy: 6.18.22 → 6.18.24
xapian: 1.4.27 → 1.4.31
xfsprogs: 6.17.0 → 6.19.0
xxHash: 0.8.3 → ∅, [32;1m-413.9 KiB[0m
xxhash: ∅ → 0.8.3, [31;1m413.9 KiB[0m
xz: 5.8.2 → 5.8.3, [31;1m41.7 KiB[0m
zenity: 4.2.1 → 4.2.2
```

</details>