### PR TITLE
Fix Firefox configuration deprecation issues

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -432,11 +432,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1777103209,
-        "narHash": "sha256-f7lpFMGpJ07txOzH8+cnwX4UphMHWAL/jwZ9Auu0XFE=",
+        "lastModified": 1777124325,
+        "narHash": "sha256-h8TpkZ2zhYgcj9oPZYJCgkMo+VgRaCsaUrQA46HjUrU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "855aac885db01ac51bedee347a34c4522e2bd4e2",
+        "rev": "6e332cda4be2e418c44b14cbdb3cbaa798c09ec1",
         "type": "github"
       },
       "original": {

--- a/home/modules/firefox/default.nix
+++ b/home/modules/firefox/default.nix
@@ -1,6 +1,7 @@
-{...}: {
+{config, ...}: {
   programs.firefox = {
     enable = true;
+    configPath = "${config.xdg.configHome}/mozilla/firefox";
     profiles = {
       default = {
         id = 0;


### PR DESCRIPTION
This pull request makes a minor adjustment to the Firefox module configuration by explicitly setting the `configPath` to use the user's XDG config directory. This helps ensure Firefox uses the correct configuration location according to the user's environment.