### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -53,11 +53,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777321974,
-        "narHash": "sha256-aIa017A9qNqZkfCciRFMinY5b69ycR11jrgZxHi0CGw=",
+        "lastModified": 1777469742,
+        "narHash": "sha256-AvXCjRNWF1PUC5afpzAX05YTFuhXpHzgVUP50lclWes=",
         "owner": "charmbracelet",
         "repo": "nur",
-        "rev": "5a52917bf5e196f7e8ed14cd118610c3e98d7d19",
+        "rev": "7f460d2941896fd489b502656c58115081ea1a60",
         "type": "github"
       },
       "original": {
@@ -254,11 +254,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777349711,
-        "narHash": "sha256-PGKgo2dO6fK603QGI+DWXdKmS09pbJjjTxwRHdhkGZA=",
+        "lastModified": 1777594677,
+        "narHash": "sha256-h90sHwoRJLRvaTpZroTvU2JRHDFj0czUafM8eqLe1RI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c1140540536d483e2730320100f6835d62c94fdf",
+        "rev": "899c08a15beae5da51a5cecd6b2b994777a948da",
         "type": "github"
       },
       "original": {
@@ -396,11 +396,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1776949667,
-        "narHash": "sha256-GMSVw35Q+294GlrTUKlx087E31z7KurReQ1YHSKp5iw=",
+        "lastModified": 1777425547,
+        "narHash": "sha256-d57AbflkNfZNoFaZDzssEq1RfPoM9dLtOGI2O+N/68Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "01fbdeef22b76df85ea168fbfe1bfd9e63681b30",
+        "rev": "ebc08544afa77957cc348ba72dc490ec73b87f68",
         "type": "github"
       },
       "original": {
@@ -412,11 +412,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1776877367,
-        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
+        "lastModified": 1777268161,
+        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
+        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
         "type": "github"
       },
       "original": {
@@ -432,11 +432,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1777364587,
-        "narHash": "sha256-nMtu6Tw3G3gwwxwZ5i3NDb+fZdKudkT1LiOUkV4dsO8=",
+        "lastModified": 1777624369,
+        "narHash": "sha256-nQOSodcDhXiKlfCKb4pE/4GBAs2FnBOD+AHVem0EqOc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bc9f0fcec6e7a4ef5443159e5fdd74f8b351b31c",
+        "rev": "c3ec6b994c235a53a28304564da6422a45230603",
         "type": "github"
       },
       "original": {
@@ -571,11 +571,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1777361593,
-        "narHash": "sha256-EqHFzxRzaKmkh2wiUoYn2iccAY3Pag1THpLNPVVXX6o=",
+        "lastModified": 1777576253,
+        "narHash": "sha256-ayu+6/+K8nA8Uhom9Wn3w/zFdSWRVzBbTbXqxShf/9A=",
         "owner": "oraios",
         "repo": "serena",
-        "rev": "5dd1a410000142ce0d9f1acbbbe9dd9dd9d2fb13",
+        "rev": "30ee9235faf1fd4ad333a3005e09b22f030db3b5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated update of `flake.lock` inputs.

All hosts built successfully against this lock file.
Merging will trigger `autodeploy.yaml`, which publishes store paths for pickup by `nixos-autodeploy`.

## Package changes

**Added: 0
0 | Removed: 0
0 | Changed: **

<details>
<summary>Full diff</summary>

```
1password: 8.12.8 → 8.12.12, [31;1m10.5 MiB[0m
boringssl: ∅ → 0.20260413.0, [31;1m3.4 MiB[0m
claude-code: 2.1.112 → 2.1.119, [31;1m154.1 MiB[0m
crush: 0.63.0 → 0.64.0, [31;1m9.4 KiB[0m
discord: 0.0.130 → 0.0.134, [32;1m-191.6 KiB[0m
docker-compose: 5.0.2 → 5.1.3, [31;1m999.5 KiB[0m
docker-containerd: 29.4.0 → 29.4.1, [31;1m28.1 KiB[0m
docker-runc: 29.4.0 → 29.4.1
docker-tini: 29.4.0 → 29.4.1
docker: 29.4.0 → 29.4.1, [31;1m80.9 KiB[0m
electron-unwrapped: 39.8.7, 40.8.5, 41.2.0 → 39.8.9, 41.3.0, [32;1m-300.4 MiB[0m
electron: 39.8.7, 40.8.5, 41.2.0 → 39.8.9, 41.3.0
firefox-unwrapped: 150.0 → 150.0.1, [32;1m-671.3 KiB[0m
firefox: 150.0 → 150.0.1, [31;1m27.6 KiB[0m
fzf: 0.71.0 → 0.72.0, [31;1m22.5 KiB[0m
home-configuration-reference: [31;1m12.1 KiB[0m
initrd-linux: 6.18.24 → 6.18.25
intel-media-driver: 26.1.2 → 26.1.6, [31;1m252.0 KiB[0m
intel-media-driver: 26.1.2 → 26.1.6, [31;1m468.0 KiB[0m
jjui: 0.10.3 → 0.10.4, [31;1m18.4 KiB[0m
linux: 6.18.24 → 6.18.25
mise: 2026.4.6 → 2026.4.20, [32;1m-4.6 MiB[0m
moby: 29.4.0 → 29.4.1, [31;1m127.3 KiB[0m
neovim-unwrapped: 0.12.1 → 0.12.2, [31;1m19.4 KiB[0m
neovim: 0.12.1 → 0.12.2
nh-unwrapped: 4.3.1 → 4.3.2, [31;1m10.5 KiB[0m
nh: 4.3.1 → 4.3.2
nix-index-with-full-db: 0.1.9-unstable-2026-02-05 → 0.1.9-unstable-2026-04-20
nix-index: 0.1.9-unstable-2026-02-05 → 0.1.9-unstable-2026-04-20, [31;1m4.4 MiB[0m
nixos-manual: [31;1m114.8 KiB[0m
nixos-system-kushtaka: 26.05.20260423.01fbdee → 26.05.20260429.ebc0854
nixos-system-snallygaster: 26.05.20260423.01fbdee → 26.05.20260429.ebc0854
nixos-system-wendigo: 26.05.20260423.01fbdee → 26.05.20260429.ebc0854
nss: 3.123 → 3.123.1
packagekit: 1.3.3 → 1.3.5, [31;1m313.2 KiB[0m
pop: 0.2.0 → 0.2.1, [32;1m-258.1 KiB[0m
protonmail-desktop: 1.12.1 → 1.13.0, [32;1m-70.0 KiB[0m
ruff: 0.15.11 → 0.15.12, [31;1m15.1 KiB[0m
serena-agent: [31;1m187.5 KiB[0m
signal-desktop: 8.6.1 → 8.8.0, [32;1m-13.1 MiB[0m
source: [31;1m875.9 KiB[0m
starship: 1.24.2 → 1.25.0, [31;1m312.6 KiB[0m
thin-provisioning-tools: 1.3.1 → 1.3.2
tree-sitter-c-neovim: 0.12.1 → 0.12.2
tree-sitter-lua-neovim: 0.12.1 → 0.12.2
tree-sitter-markdown-neovim: 0.12.1 → 0.12.2
tree-sitter-markdown_inline-neovim: 0.12.1 → 0.12.2
tree-sitter-query-neovim: 0.12.1 → 0.12.2
tree-sitter-vim-neovim: 0.12.1 → 0.12.2
tree-sitter-vimdoc-neovim: 0.12.1 → 0.12.2
uriparser: 1.0.0 → 1.0.1
vimplugin-conform.nvim: 9.1.0-unstable-2026-03-10 → 9.1.0-unstable-2026-04-23
vimplugin-fzf: 0.71.0 → 0.72.0, [31;1m28.8 KiB[0m
vimplugin-nvim-tree.lua: 1.17.0-unstable-2026-04-16 → 1.17.0-unstable-2026-04-25
vimplugin-vim-airline: 0.11-unstable-2026-04-13 → 0.11-unstable-2026-04-22
x86_energy_perf_policy: 6.18.24 → 6.18.25
```

</details>