### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -50,14 +50,15 @@
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
-        ]
+        ],
+        "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1777469742,
-        "narHash": "sha256-AvXCjRNWF1PUC5afpzAX05YTFuhXpHzgVUP50lclWes=",
+        "lastModified": 1778100745,
+        "narHash": "sha256-5SlF5pVxQ/Hn+sJTuZ5yOpLvgfDRWBvxdr0AQA5uxjw=",
         "owner": "charmbracelet",
         "repo": "nur",
-        "rev": "7f460d2941896fd489b502656c58115081ea1a60",
+        "rev": "9b3c5942a61e7f4bd98201dfe35c8b3339b542c1",
         "type": "github"
       },
       "original": {
@@ -254,11 +255,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777594677,
-        "narHash": "sha256-h90sHwoRJLRvaTpZroTvU2JRHDFj0czUafM8eqLe1RI=",
+        "lastModified": 1778144356,
+        "narHash": "sha256-dGM+QCstz/DyLB68+JK5GWyMx4QSqmOJEVgZmy63d/g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "899c08a15beae5da51a5cecd6b2b994777a948da",
+        "rev": "e4419d3123b780d5f4c0bceeace450424387638c",
         "type": "github"
       },
       "original": {
@@ -293,11 +294,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777181277,
-        "narHash": "sha256-yVJbd07ortDRAttDFmDV5p220aOLTHgVAx//0nW/xW8=",
+        "lastModified": 1777787189,
+        "narHash": "sha256-2KUbS/HhzWW3kkkY1+RiWj9mJ76VEXw8lBJzcCFKzfY=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "b8eb7acee0f7604fe1bf6a5b3dcf5254369180fa",
+        "rev": "2dea2b920e7127b3afa8506713f23536651de312",
         "type": "github"
       },
       "original": {
@@ -332,11 +333,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1776983936,
-        "narHash": "sha256-ZOQyNqSvJ8UdrrqU1p7vaFcdL53idK+LOM8oRWEWh6o=",
+        "lastModified": 1777917524,
+        "narHash": "sha256-k+LVe9YaO2BEPB9AaCtTtOMCeGi4dxDo6gt4Un3qoPY=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "2096f3f411ce46e88a79ae4eafcfc9df8ed41c61",
+        "rev": "df7783100babf59001340a7a874ba3824e441ecb",
         "type": "github"
       },
       "original": {
@@ -396,11 +397,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1777425547,
-        "narHash": "sha256-d57AbflkNfZNoFaZDzssEq1RfPoM9dLtOGI2O+N/68Q=",
+        "lastModified": 1778036283,
+        "narHash": "sha256-62EWg6lI0qyzm7oAx5cAnGkLutvJsRBe0KkEW2JDZCE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ebc08544afa77957cc348ba72dc490ec73b87f68",
+        "rev": "ed67bc86e84e51d4a88e73c7fd36006dc876476f",
         "type": "github"
       },
       "original": {
@@ -412,11 +413,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1777268161,
-        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
         "type": "github"
       },
       "original": {
@@ -432,11 +433,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1777624369,
-        "narHash": "sha256-nQOSodcDhXiKlfCKb4pE/4GBAs2FnBOD+AHVem0EqOc=",
+        "lastModified": 1778143139,
+        "narHash": "sha256-DHYwfOglOIpeYREK+ZKG9DvDtbRAt1el1BHAQhQBZUU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c3ec6b994c235a53a28304564da6422a45230603",
+        "rev": "fb8e20e58e42d50d8084f0e8f6c4c333035aaefd",
         "type": "github"
       },
       "original": {
@@ -571,11 +572,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1777576253,
-        "narHash": "sha256-ayu+6/+K8nA8Uhom9Wn3w/zFdSWRVzBbTbXqxShf/9A=",
+        "lastModified": 1778089967,
+        "narHash": "sha256-TD9AIhkQICL0vQri+cFpkKinKJUqu8Bw3AhEFmCUuCs=",
         "owner": "oraios",
         "repo": "serena",
-        "rev": "30ee9235faf1fd4ad333a3005e09b22f030db3b5",
+        "rev": "6882f2e1f00181dccb626d8c47dd193641be9334",
         "type": "github"
       },
       "original": {
@@ -626,6 +627,27 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "charmbracelet-nur",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769353635,
+        "narHash": "sha256-J0G1ACrUK29M0THPAsz429eZX07GmR9Bs/b0pB3N0dQ=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "f46bb205f239b415309f58166f8df6919fa88377",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
         "type": "github"
       }
     },


### PR DESCRIPTION
Automated update of `flake.lock` inputs.

All hosts built successfully against this lock file.
Merging will trigger `autodeploy.yaml`, which publishes store paths for pickup by `nixos-autodeploy`.

## Package changes

**Added: 0
0 | Removed: 1 | Changed: **

<details>
<summary>Full diff</summary>

```
55-nixos-aslr-entropy.conf: ∅ → ε
cfitsio: 4.6.3 → 4.6.4, [31;1m8.0 KiB[0m
claude-code: 2.1.119 → 2.1.128, [31;1m3.4 MiB[0m
crush: 0.64.0 → 0.66.0, [31;1m151.2 KiB[0m
firefox-unwrapped: [31;1m210.3 KiB[0m
firefox: [32;1m-27.8 KiB[0m
gh: 2.91.0 → 2.92.0, [31;1m28.7 KiB[0m
gofumpt: 0.9.2 → 0.10.0, [32;1m-913.5 KiB[0m
golangci-lint: 2.11.4 → 2.12.1, [32;1m-956.2 KiB[0m
home-configuration-reference: [31;1m49.9 KiB[0m
initrd-linux: 6.18.25 → 6.18.26
initrd-linux: 6.18.25 → 6.18.26, [32;1m-8.8 KiB[0m
libXNVCtrl: 595.58.03 → 595.71.05
libblake3: 1.8.4 → 1.8.5
linux: 6.18.25 → 6.18.26, [32;1m-14.3 KiB[0m
mesa: 26.0.5 → 26.0.6
mesa: 26.0.5 → 26.0.6, [31;1m8.2 KiB[0m
mullvad-vpn: 2025.14 → 2026.1, [32;1m-8.5 MiB[0m
nano: 8.7.1 → 9.0, [31;1m93.6 KiB[0m
nix-cmd: 2.30.4+1, 2.34.6 → 2.30.5+1, 2.34.7
nix-expr: 2.30.4+1, 2.34.6 → 2.30.5+1, 2.34.7
nix-fetchers: 2.30.4+1, 2.34.6 → 2.30.5+1, 2.34.7
nix-flake: 2.30.4+1, 2.34.6 → 2.30.5+1, 2.34.7
nix-index-with-full-db: 0.1.9-unstable-2026-04-20 → 0.1.10
nix-index: 0.1.9-unstable-2026-04-20 → 0.1.10, [32;1m-29.7 KiB[0m
nix-main: 2.30.4+1, 2.34.6 → 2.30.5+1, 2.34.7
nix-manual: 2.34.6 → 2.34.7
nix-nswrapper: 2.34.6 → 2.34.7
nix-store: 2.30.4+1, 2.34.6 → 2.30.5+1, 2.34.7
nix-util: 2.30.4+1, 2.34.6 → 2.30.5+1, 2.34.7, [31;1m13.3 KiB[0m
nix: 2.34.6 → 2.34.7, [31;1m9.1 KiB[0m
nixos-system-kushtaka: 26.05.20260429.ebc0854 → 26.05.20260506.ed67bc8
nixos-system-snallygaster: 26.05.20260429.ebc0854 → 26.05.20260506.ed67bc8
nixos-system-wendigo: 26.05.20260429.ebc0854 → 26.05.20260506.ed67bc8
ntfs3g: 2022.10.3 → 2026.2.25, [31;1m12.7 KiB[0m
openjdk-headless-minimal-jre: 21.0.10+7 → ∅, [32;1m-89.0 MiB[0m
openjdk-minimal-jre: ∅ → 21.0.10+7, [31;1m89.5 MiB[0m
protonmail-bridge: 3.24.1 → 3.24.2
python3.13-sentry-sdk: 2.58.0 → 2.59.0, [31;1m116.7 KiB[0m
qtkeychain: 0.15.0 → 0.16.0, [31;1m22.6 KiB[0m
rclone: 1.73.5 → 1.74.0, [31;1m1.9 MiB[0m
sd-switch: 0.6.2 → 0.6.3, [31;1m15.1 KiB[0m
serena-agent: [31;1m219.9 KiB[0m
source: [31;1m772.8 KiB[0m
starship: 1.25.0 → 1.25.1, [31;1m8.5 KiB[0m
strace: 6.19 → 7.0, [31;1m1.1 MiB[0m
vimplugin-luajit2.1-lualine.nvim-scm: 3-unstable-scm-3 → 4-unstable-scm-4
vimplugin-nightfox.nvim: 3.10.0-unstable-2025-02-09 → 3.10.0-unstable-2026-05-03
vimplugin-nvim-surround: 4.0.4-unstable-2026-04-05 → 4.0.5-unstable-2026-05-02
vimplugin-nvim-tree.lua: 1.17.0-unstable-2026-04-25 → 1.17.0-unstable-2026-04-30
vimplugin-vim-airline: 0.11-unstable-2026-04-22 → 0.12
vpl-gpu-rt: 26.1.4 → 26.1.6, [32;1m-15.1 KiB[0m
x86_energy_perf_policy: 6.18.25 → 6.18.26
xwayland: 24.1.10 → 24.1.11
```

</details>