### PR TITLE
Enhance AI features and fix VPN configuration issues

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -33,7 +33,8 @@
       "mcp__serena__write_memory",
       "Read(//home/grue/.claude/plugins/marketplaces/daymade-skills/skill-creator/**)",
       "Bash(python3 -m scripts.init_skill --help)",
-      "Skill(nix-config)"
+      "Skill(nix-config)",
+      "WebSearch"
     ]
   },
   "outputStyle": "Explanatory",

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -3,21 +3,26 @@ project_name: "nix-config"
 
 
 # list of languages for which language servers are started; choose from:
-#   al                  bash                clojure             cpp                 csharp
-#   csharp_omnisharp    dart                elixir              elm                 erlang
-#   fortran             fsharp              go                  groovy              haskell
-#   java                julia               kotlin              lua                 markdown
-#   matlab              nix                 pascal              perl                php
-#   php_phpactor        powershell          python              python_jedi         r
-#   rego                ruby                ruby_solargraph     rust                scala
-#   swift               terraform           toml                typescript          typescript_vts
-#   vue                 yaml                zig
+#   al                  angular             ansible             bash                clojure
+#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
+#   dart                elixir              elm                 erlang              fortran
+#   fsharp              go                  groovy              haskell             haxe
+#   hlsl                html                java                json                julia
+#   kotlin              lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        powershell          python
+#   python_jedi         python_ty           r                   rego                ruby
+#   ruby_solargraph     rust                scala               scss                solidity
+#   swift               systemverilog       terraform           toml                typescript
+#   typescript_vts      vue                 yaml                zig
 #   (This list may be outdated. For the current list, see values of Language enum here:
 #   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
 #   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
 # Note:
 #   - For C, use cpp
 #   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
 #   - For Free Pascal/Lazarus, use pascal
 # Special requirements:
 #   Some languages require additional setup/installations.
@@ -65,53 +70,17 @@ read_only: false
 
 # list of tool names to exclude.
 # This extends the existing exclusions (e.g. from the global configuration)
-#
-# Below is the complete list of tools for convenience.
-# To make sure you have the latest list of tools, and to view their descriptions, 
-# execute `uv run scripts/print_tool_overview.py`.
-#
-#  * `activate_project`: Activates a project by name.
-#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
-#  * `create_text_file`: Creates/overwrites a file in the project directory.
-#  * `delete_lines`: Deletes a range of lines within a file.
-#  * `delete_memory`: Deletes a memory from Serena's project-specific memory store.
-#  * `execute_shell_command`: Executes a shell command.
-#  * `find_referencing_code_snippets`: Finds code snippets in which the symbol at the given location is referenced.
-#  * `find_referencing_symbols`: Finds symbols that reference the symbol at the given location (optionally filtered by type).
-#  * `find_symbol`: Performs a global (or local) search for symbols with/containing a given name/substring (optionally filtered by type).
-#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
-#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
-#  * `initial_instructions`: Gets the initial instructions for the current project.
-#     Should only be used in settings where the system prompt cannot be set,
-#     e.g. in clients you have no control over, like Claude Desktop.
-#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
-#  * `insert_at_line`: Inserts content at a given line in a file.
-#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
-#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
-#  * `list_memories`: Lists memories in Serena's project-specific memory store.
-#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
-#  * `prepare_for_new_conversation`: Provides instructions for preparing for a new conversation (in order to continue with the necessary context).
-#  * `read_file`: Reads a file within the project directory.
-#  * `read_memory`: Reads the memory with the given name from Serena's project-specific memory store.
-#  * `remove_project`: Removes a project from the Serena configuration.
-#  * `replace_lines`: Replaces a range of lines within a file with new content.
-#  * `replace_symbol_body`: Replaces the full definition of a symbol.
-#  * `restart_language_server`: Restarts the language server, may be necessary when edits not through Serena happen.
-#  * `search_for_pattern`: Performs a search for a pattern in the project.
-#  * `summarize_changes`: Provides instructions for summarizing the changes made to the codebase.
-#  * `switch_modes`: Activates modes by providing a list of their names
-#  * `think_about_collected_information`: Thinking tool for pondering the completeness of collected information.
-#  * `think_about_task_adherence`: Thinking tool for determining whether the agent is still on track with the current task.
-#  * `think_about_whether_you_are_done`: Thinking tool for determining whether the task is truly completed.
-#  * `write_memory`: Writes a named memory (for future reference) to Serena's project-specific memory store.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 excluded_tools: []
 
 # list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
 # This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 included_optional_tools: []
 
 # fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
 # This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 fixed_tools: []
 
 # list of mode names to that are always to be included in the set of active modes
@@ -122,11 +91,14 @@ fixed_tools: []
 # Set this to a list of mode names to always include the respective modes for this project.
 base_modes:
 
-# list of mode names that are to be activated by default.
-# The full set of modes to be activated is base_modes + default_modes.
-# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
 # Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
 # This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
 default_modes:
 
 # initial prompt for the project. It will always be given to the LLM upon activating the project
@@ -150,3 +122,19 @@ read_only_memory_patterns: []
 # Extends the list from the global configuration, merging the two lists.
 # Example: ["_archive/.*", "_episodes/.*"]
 ignored_memory_patterns: []
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries.
+# Currently supported for: TypeScript.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+additional_workspace_folders: []

--- a/flake.lock
+++ b/flake.lock
@@ -255,11 +255,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778144356,
-        "narHash": "sha256-dGM+QCstz/DyLB68+JK5GWyMx4QSqmOJEVgZmy63d/g=",
+        "lastModified": 1778009629,
+        "narHash": "sha256-nUoQtf4Zq7DRYJrfv904hjrxjAlWVP6a1pNNFKx3FCg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e4419d3123b780d5f4c0bceeace450424387638c",
+        "rev": "00ed86e58bb6979a7921859fd1615d19382eac5c",
         "type": "github"
       },
       "original": {
@@ -433,11 +433,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1778143139,
-        "narHash": "sha256-DHYwfOglOIpeYREK+ZKG9DvDtbRAt1el1BHAQhQBZUU=",
+        "lastModified": 1778094762,
+        "narHash": "sha256-X8uV6nYMkY1xKecKTC4wbTP/5EMwTvZeEuSI/LWsA1k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fb8e20e58e42d50d8084f0e8f6c4c333035aaefd",
+        "rev": "dcdd79dd589f1aa666a35da7a8fd07cf17f1527b",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -54,11 +54,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1778100745,
-        "narHash": "sha256-5SlF5pVxQ/Hn+sJTuZ5yOpLvgfDRWBvxdr0AQA5uxjw=",
+        "lastModified": 1778274803,
+        "narHash": "sha256-a3a/7mXXaDssIhHrTkHsjoV0h/qL3yWJXmpD1P18bEg=",
         "owner": "charmbracelet",
         "repo": "nur",
-        "rev": "9b3c5942a61e7f4bd98201dfe35c8b3339b542c1",
+        "rev": "0300425a233287e5fddcf9795968e47222c5ce49",
         "type": "github"
       },
       "original": {
@@ -255,11 +255,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778009629,
-        "narHash": "sha256-nUoQtf4Zq7DRYJrfv904hjrxjAlWVP6a1pNNFKx3FCg=",
+        "lastModified": 1778248595,
+        "narHash": "sha256-dhFgEjoeJMYN/7OY6xfxS799YB4IjbbYXTjyGIJyLpc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "00ed86e58bb6979a7921859fd1615d19382eac5c",
+        "rev": "fdb2ccba9d5e1238d32e0c4a3ec1a277efa80c1d",
         "type": "github"
       },
       "original": {
@@ -294,11 +294,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777787189,
-        "narHash": "sha256-2KUbS/HhzWW3kkkY1+RiWj9mJ76VEXw8lBJzcCFKzfY=",
+        "lastModified": 1778240325,
+        "narHash": "sha256-d2HIS7LpfI0lgxiXCXLjxrHl3eIdNvAVexOu0xiM488=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "2dea2b920e7127b3afa8506713f23536651de312",
+        "rev": "dd2d0e3f6ba00af01b9498f5697173bdc2524bee",
         "type": "github"
       },
       "original": {
@@ -333,11 +333,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1777917524,
-        "narHash": "sha256-k+LVe9YaO2BEPB9AaCtTtOMCeGi4dxDo6gt4Un3qoPY=",
+        "lastModified": 1778143761,
+        "narHash": "sha256-lkesY6x2X2qxlqLM7CT2iM/0rP2JB7fruPN3h8POXmI=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "df7783100babf59001340a7a874ba3824e441ecb",
+        "rev": "3bcaa367d4c550d687a17ac792fd5cda214ee871",
         "type": "github"
       },
       "original": {
@@ -397,11 +397,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1778036283,
-        "narHash": "sha256-62EWg6lI0qyzm7oAx5cAnGkLutvJsRBe0KkEW2JDZCE=",
+        "lastModified": 1778124196,
+        "narHash": "sha256-pYEytCNic/czazbV9r3tbQ6BZzqRBg/41x2dIC5ymOo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ed67bc86e84e51d4a88e73c7fd36006dc876476f",
+        "rev": "68a8af93ff4297686cb68880845e61e5e2e41d92",
         "type": "github"
       },
       "original": {
@@ -433,11 +433,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1778094762,
-        "narHash": "sha256-X8uV6nYMkY1xKecKTC4wbTP/5EMwTvZeEuSI/LWsA1k=",
+        "lastModified": 1778285060,
+        "narHash": "sha256-kti9S5YVuAKG78KQBsGkTvFiIsOJrjuouogqcd1foyM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dcdd79dd589f1aa666a35da7a8fd07cf17f1527b",
+        "rev": "e27df49d002b1f0d560a4d80ccf2e6cc3bc7a008",
         "type": "github"
       },
       "original": {
@@ -572,11 +572,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1778089967,
-        "narHash": "sha256-TD9AIhkQICL0vQri+cFpkKinKJUqu8Bw3AhEFmCUuCs=",
+        "lastModified": 1778234906,
+        "narHash": "sha256-GiiBEIt1R6Ke93XYx3sKyMO9l+J5zJ5kk5IVkAv0nvY=",
         "owner": "oraios",
         "repo": "serena",
-        "rev": "6882f2e1f00181dccb626d8c47dd193641be9334",
+        "rev": "ab98ea676253e7a4efee7bc9f9aa7caf51cc6c52",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -95,7 +95,7 @@
         modules = [
           nur.modules.nixos.default
           agenix.nixosModules.default
-          ({...}: {config = {nixpkgs.overlays = overlays;};})
+          (_: {config = {nixpkgs.overlays = overlays;};})
           {
             environment.systemPackages = [
               agenix.packages.${system}.default

--- a/home/modules/1password/default.nix
+++ b/home/modules/1password/default.nix
@@ -1,15 +1,9 @@
 {pkgs, ...}: {
-  systemd.user.services."1password" = {
-    Unit = {
-      Description = "1Password GUI";
-      After = "graphical-session.target";
-    };
-    Service = {
-      ExecStart = "${pkgs._1password-gui}/bin/1password --silent";
-      Restart = "on-failure";
-    };
-    Install = {
-      WantedBy = ["graphical-session.target"];
-    };
-  };
+  xdg.configFile."autostart/1password.desktop".text = ''
+    [Desktop Entry]
+    Type=Application
+    Name=1Password
+    Exec=${pkgs._1password-gui}/bin/1password
+    X-GNOME-Autostart-enabled=true
+  '';
 }

--- a/home/modules/atuin/default.nix
+++ b/home/modules/atuin/default.nix
@@ -1,4 +1,4 @@
-{...}: {
+_: {
   programs.atuin = {
     enable = true;
     settings = {

--- a/home/modules/claude/default.nix
+++ b/home/modules/claude/default.nix
@@ -19,6 +19,7 @@
       effortLevel = "medium";
       model = "opusplan";
       promptSuggestionEnabled = false;
+      includeGitInstructions = false;
 
       # ── Permissions ───────────────────────────────────────────────────────
       # Only read-only commands are pre-approved here. Commands that make

--- a/home/modules/delta/default.nix
+++ b/home/modules/delta/default.nix
@@ -1,4 +1,4 @@
-{...}: {
+_: {
   programs.delta = {
     enable = true;
     enableGitIntegration = true;

--- a/home/modules/direnv/default.nix
+++ b/home/modules/direnv/default.nix
@@ -1,4 +1,4 @@
-{...}: {
+_: {
   programs.direnv = {
     enable = true;
     enableZshIntegration = true;

--- a/home/modules/eza/default.nix
+++ b/home/modules/eza/default.nix
@@ -1,4 +1,4 @@
-{...}: {
+_: {
   programs.eza = {
     enable = true;
     enableZshIntegration = true;

--- a/home/modules/fzf/default.nix
+++ b/home/modules/fzf/default.nix
@@ -1,4 +1,4 @@
-{...}: {
+_: {
   programs.fzf = {
     enable = true;
     enableZshIntegration = true;

--- a/home/modules/kitty/default.nix
+++ b/home/modules/kitty/default.nix
@@ -5,9 +5,11 @@
 
     shellIntegration.enableZshIntegration = true;
     themeFile = "gruvbox-dark";
-    font.package = pkgs.fira-code;
-    font.name = "Fira Code";
-    font.size = 14;
+    font = {
+      package = pkgs.fira-code;
+      name = "Fira Code";
+      size = 14;
+    };
 
     keybindings = {
       "ctrl+shift+t" = "new_tab_with_cwd";

--- a/home/modules/mise/default.nix
+++ b/home/modules/mise/default.nix
@@ -1,4 +1,4 @@
-{...}: {
+_: {
   programs.mise = {
     enable = true;
 

--- a/home/modules/mullvad/default.nix
+++ b/home/modules/mullvad/default.nix
@@ -1,4 +1,4 @@
-{...}: {
+_: {
   programs.mullvad-vpn = {
     enable = true;
 

--- a/home/modules/nvim/keymaps.lua
+++ b/home/modules/nvim/keymaps.lua
@@ -69,5 +69,10 @@ end, { desc = "Format file" })
 -- Set working directory to current file
 map("n", "<Leader>.", ":lcd %:p:h<CR>", { desc = "Set cwd to file dir" })
 
+-- Toggle LSP inlay hints
+map("n", "<Leader>li", function()
+  vim.lsp.inlay_hint.enable(not vim.lsp.inlay_hint.is_enabled())
+end, { desc = "Toggle inlay hints" })
+
 -- FixWhitespace command
 vim.api.nvim_create_user_command("FixWhitespace", [[%s/\s\+$//e]], {})

--- a/home/modules/signal/default.nix
+++ b/home/modules/signal/default.nix
@@ -1,0 +1,11 @@
+{pkgs, ...}: {
+  home.packages = [pkgs.signal-desktop];
+
+  xdg.configFile."autostart/signal-desktop.desktop".text = ''
+    [Desktop Entry]
+    Type=Application
+    Name=Signal
+    Exec=${pkgs.signal-desktop}/bin/signal-desktop
+    X-GNOME-Autostart-enabled=true
+  '';
+}

--- a/home/modules/ssh/default.nix
+++ b/home/modules/ssh/default.nix
@@ -12,53 +12,47 @@
   # git and jj need a file path, not a string, to reference the signing key.
   signingKeyFile = pkgs.writeText "grue-signing.pub" signingKeyPub;
 in {
-  # SSH client configuration
-  programs.ssh = {
-    enable = true;
-    # We manage matchBlocks."*" ourselves; opt out of the deprecated default
-    # Host * block that home-manager injects automatically.
-    enableDefaultConfig = false;
-  };
+  programs = {
+    # SSH client configuration
+    ssh = {
+      enable = true;
+      # We manage matchBlocks."*" ourselves; opt out of the deprecated default
+      # Host * block that home-manager injects automatically.
+      enableDefaultConfig = false;
 
-  # Route all SSH auth through 1Password agent.
-  # Uses absolute path via config.home.homeDirectory to ensure correct
-  # expansion in all contexts (interactive and non-interactive git operations).
-  # Note: IdentityAgent with 1P means no key files on disk — 1P holds the private key.
-  programs.ssh.matchBlocks."*" = {
-    identityAgent = "${config.home.homeDirectory}/.1password/agent.sock";
-    serverAliveInterval = 60;
-    serverAliveCountMax = 3;
-  };
+      matchBlocks = {
+        # Route all SSH auth through 1Password agent.
+        # Uses absolute path via config.home.homeDirectory to ensure correct
+        # expansion in all contexts (interactive and non-interactive git operations).
+        # Note: IdentityAgent with 1P means no key files on disk — 1P holds the private key.
+        "*" = {
+          identityAgent = "${config.home.homeDirectory}/.1password/agent.sock";
+          serverAliveInterval = 60;
+          serverAliveCountMax = 3;
+        };
 
-  # Tailscale hosts — surfaced to wishlist via ~/.ssh/config.
-  # MagicDNS domain: armadillo-toad.ts.net
-  programs.ssh.matchBlocks."wendigo" = {
-    hostname = "wendigo.armadillo-toad.ts.net";
-  };
-  programs.ssh.matchBlocks."kushtaka" = {
-    hostname = "kushtaka.armadillo-toad.ts.net";
-  };
-  programs.ssh.matchBlocks."snallygaster" = {
-    hostname = "snallygaster.armadillo-toad.ts.net";
-  };
+        # Tailscale hosts — surfaced to wishlist via ~/.ssh/config.
+        # MagicDNS domain: armadillo-toad.ts.net
+        "wendigo".hostname = "wendigo.armadillo-toad.ts.net";
+        "kushtaka".hostname = "kushtaka.armadillo-toad.ts.net";
+        "snallygaster".hostname = "snallygaster.armadillo-toad.ts.net";
+      };
+    };
 
-  # Git SSH commit signing.
-  # Using programs.git.signing (typed home-manager options) rather than
-  # raw settings keys — the typed API is validated by home-manager and
-  # automatically wires the ssh-keygen binary when format = "ssh".
-  programs.git = {
-    signing = {
+    # Git SSH commit signing.
+    # Using programs.git.signing (typed home-manager options) rather than
+    # raw settings keys — the typed API is validated by home-manager and
+    # automatically wires the ssh-keygen binary when format = "ssh".
+    git.signing = {
       format = "ssh";
       # The .pub file path tells git which key to request from the SSH agent.
       # The agent (1Password) performs the actual signing; no private key on disk.
       key = "${signingKeyFile}";
       signByDefault = true;
     };
-  };
 
-  # jujutsu commit signing via SSH
-  programs.jujutsu.settings = {
-    signing = {
+    # jujutsu commit signing via SSH
+    jujutsu.settings.signing = {
       sign-all = true;
       backend = "ssh";
       key = "${signingKeyFile}";

--- a/home/modules/vim/keymaps.nix
+++ b/home/modules/vim/keymaps.nix
@@ -1,5 +1,5 @@
 # Vim keymaps and plugin configuration
-{...}: {
+_: {
   programs.vim.extraConfig = ''
     " General settings
     set gcr=a:blinkon0

--- a/home/modules/vim/settings.nix
+++ b/home/modules/vim/settings.nix
@@ -1,5 +1,5 @@
 # Vim settings
-{...}: {
+_: {
   programs.vim.settings = {
     # Search
     ignorecase = true;

--- a/home/modules/zoxide/default.nix
+++ b/home/modules/zoxide/default.nix
@@ -1,4 +1,4 @@
-{...}: {
+_: {
   programs.zoxide = {
     enable = true;
     enableZshIntegration = true;

--- a/home/roles/base.nix
+++ b/home/roles/base.nix
@@ -26,6 +26,7 @@
     ../modules/1password
     ../modules/kitty
     ../modules/mullvad
+    ../modules/signal
   ];
 
   #### Home-Manager essentials ####
@@ -53,7 +54,6 @@
 
     # GUI stuff
     discord
-    signal-desktop
     vlc
   ];
 

--- a/home/roles/base.nix
+++ b/home/roles/base.nix
@@ -30,39 +30,41 @@
   ];
 
   #### Home-Manager essentials ####
-  programs.home-manager.enable = true;
   xdg.enable = true;
   fonts.fontconfig.enable = true;
 
-  #### nix-index-database + comma ####
-  # Provides fast command-not-found via pre-built indexes
-  # comma lets you run any command temporarily: , cowsay hello
-  programs.nix-index-database.comma.enable = true;
-
-  #### Common CLI / UX tools ####
-  home.packages = with pkgs; [
-    bat
-    curl
-    fd
-    just
-    ripgrep
-    sd
-    unzip
-    wget
-    xh
-    zip
-
-    # GUI stuff
-    discord
-    vlc
-  ];
-
-  #### Default environment setup ####
-  home.sessionVariables = {
-    EDITOR = lib.mkDefault "nvim";
-    LANG = "en_US.UTF-8";
-    PAGER = lib.mkDefault "less";
+  programs = {
+    home-manager.enable = true;
+    # Provides fast command-not-found via pre-built indexes
+    # comma lets you run any command temporarily: , cowsay hello
+    nix-index-database.comma.enable = true;
+    fzf.enable = true;
   };
 
-  programs.fzf.enable = true;
+  #### Common CLI / UX tools ####
+  home = {
+    packages = with pkgs; [
+      bat
+      curl
+      fd
+      just
+      ripgrep
+      sd
+      unzip
+      wget
+      xh
+      zip
+
+      # GUI stuff
+      discord
+      vlc
+    ];
+
+    #### Default environment setup ####
+    sessionVariables = {
+      EDITOR = lib.mkDefault "nvim";
+      LANG = "en_US.UTF-8";
+      PAGER = lib.mkDefault "less";
+    };
+  };
 }

--- a/home/users/grue.nix
+++ b/home/users/grue.nix
@@ -50,7 +50,7 @@
     secret,
     env,
   }: let
-    path = config.age.secrets.${secret}.path;
+    inherit (config.age.secrets.${secret}) path;
   in ''
     if [[ -r "${path}" ]]; then
       ${env}="$(< "${path}")"
@@ -71,13 +71,16 @@ in {
     ../modules/pop
   ];
 
-  home.username = "grue";
-  home.homeDirectory = "/home/grue";
-  home.stateVersion = "25.05";
+  home = {
+    username = "grue";
+    homeDirectory = "/home/grue";
+    stateVersion = "25.05";
+  };
 
-  programs.git.settings.user = identity;
-
-  programs.jujutsu.settings.user = identity;
+  programs = {
+    git.settings.user = identity;
+    jujutsu.settings.user = identity;
+  };
 
   # Personal touches
   home.packages = with pkgs; [

--- a/home/users/jsquats.nix
+++ b/home/users/jsquats.nix
@@ -1,5 +1,5 @@
 # home/users/jsquats.nix
-{pkgs, ...}: {
+{...}: {
   imports = [
     ../roles/base.nix
     ../roles/player.nix

--- a/home/users/sukey.nix
+++ b/home/users/sukey.nix
@@ -1,5 +1,5 @@
 # /home/users/sukey.nix
-{pkgs, ...}: {
+{...}: {
   imports = [
     ../roles/base.nix
   ];

--- a/nixos/common/1password.nix
+++ b/nixos/common/1password.nix
@@ -1,4 +1,4 @@
-{...}: {
+_: {
   programs._1password.enable = true;
   programs._1password-gui = {
     enable = true;

--- a/nixos/common/firefox.nix
+++ b/nixos/common/firefox.nix
@@ -1,4 +1,4 @@
-{...}: let
+_: let
   lock-false = {
     Value = false;
     Status = "locked";

--- a/nixos/common/monitoring.nix
+++ b/nixos/common/monitoring.nix
@@ -8,7 +8,7 @@
 #
 # Grafana binds to 0.0.0.0:3000 but is only reachable via the tailscale0
 # interface (trusted in nixos/common/tailscale.nix).
-{...}: {
+_: {
   age.secrets.grafanaKey = {
     file = ../../secrets/grafanaKey.age;
     owner = "grafana";

--- a/nixos/common/nas.nix
+++ b/nixos/common/nas.nix
@@ -4,7 +4,7 @@
 #
 # NAS UID mapping (must match NixOS UIDs in users.nix):
 #   grue (2001) / jsquats (2003) / sukey (2004)
-{...}: let
+_: let
   nasHost = "192.168.86.22"; # TODO: at some point change this to an fqdn
   nfsOptions = [
     "vers=4.1"

--- a/nixos/common/users.nix
+++ b/nixos/common/users.nix
@@ -1,45 +1,53 @@
 {pkgs, ...}: {
-  users.groups.grue.gid = 2001;
-  users.groups.jsquats.gid = 2003;
-  users.groups.sukey.gid = 2004;
+  users = {
+    groups = {
+      grue.gid = 2001;
+      jsquats.gid = 2003;
+      sukey.gid = 2004;
+    };
 
-  users.users.grue = {
-    isNormalUser = true;
-    uid = 2001;
-    group = "grue";
-    description = "grue";
-    extraGroups = [
-      "docker"
-      "networkmanager"
-      "wheel"
-    ];
-    shell = pkgs.zsh;
+    users = {
+      grue = {
+        isNormalUser = true;
+        uid = 2001;
+        group = "grue";
+        description = "grue";
+        extraGroups = [
+          "docker"
+          "networkmanager"
+          "wheel"
+        ];
+        shell = pkgs.zsh;
 
-    openssh.authorizedKeys.keys = [
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOeLAZg365wMtiUxEAXWscq4jSRhXeHH8X3NNcTT0DoP"
-    ];
-  };
+        openssh.authorizedKeys.keys = [
+          "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOeLAZg365wMtiUxEAXWscq4jSRhXeHH8X3NNcTT0DoP"
+        ];
+      };
 
-  users.users.jsquats = {
-    isNormalUser = true;
-    uid = 2003;
-    group = "jsquats";
-    description = "jasper";
-    extraGroups = ["networkmanager"];
-    shell = pkgs.bash;
-  };
+      jsquats = {
+        isNormalUser = true;
+        uid = 2003;
+        group = "jsquats";
+        description = "jasper";
+        extraGroups = ["networkmanager"];
+        shell = pkgs.bash;
+      };
 
-  users.users.sukey = {
-    isNormalUser = true;
-    uid = 2004;
-    group = "sukey";
-    description = "sukey";
-    extraGroups = ["networkmanager"];
-    shell = pkgs.zsh;
+      sukey = {
+        isNormalUser = true;
+        uid = 2004;
+        group = "sukey";
+        description = "sukey";
+        extraGroups = ["networkmanager"];
+        shell = pkgs.zsh;
+      };
+    };
   };
 
   # Attach Home-Manager configs
-  home-manager.users.grue = import ../../home/users/grue.nix;
-  home-manager.users.jsquats = import ../../home/users/jsquats.nix;
-  home-manager.users.sukey = import ../../home/users/sukey.nix;
+  home-manager.users = {
+    grue = import ../../home/users/grue.nix;
+    jsquats = import ../../home/users/jsquats.nix;
+    sukey = import ../../home/users/sukey.nix;
+  };
 }

--- a/nixos/hosts/bunyip/hardware-configuration.nix
+++ b/nixos/hosts/bunyip/hardware-configuration.nix
@@ -11,10 +11,12 @@
     (modulesPath + "/installer/scan/not-detected.nix")
   ];
 
-  boot.initrd.availableKernelModules = ["xhci_pci" "ahci" "nvme" "usb_storage" "sd_mod"];
-  boot.initrd.kernelModules = [];
-  boot.kernelModules = ["kvm-intel"];
-  boot.extraModulePackages = [];
+  boot = {
+    initrd.availableKernelModules = ["xhci_pci" "ahci" "nvme" "usb_storage" "sd_mod"];
+    initrd.kernelModules = [];
+    kernelModules = ["kvm-intel"];
+    extraModulePackages = [];
+  };
 
   fileSystems."/" = {
     device = "/dev/disk/by-label/nixos";

--- a/nixos/hosts/kushtaka/hardware-configuration.nix
+++ b/nixos/hosts/kushtaka/hardware-configuration.nix
@@ -11,16 +11,18 @@
     (modulesPath + "/installer/scan/not-detected.nix")
   ];
 
-  boot.initrd.availableKernelModules = [
-    "xhci_pci"
-    "nvme"
-    "usb_storage"
-    "sd_mod"
-    "rtsx_pci_sdmmc"
-  ];
-  boot.initrd.kernelModules = [];
-  boot.kernelModules = ["kvm-intel"];
-  boot.extraModulePackages = [];
+  boot = {
+    initrd.availableKernelModules = [
+      "xhci_pci"
+      "nvme"
+      "usb_storage"
+      "sd_mod"
+      "rtsx_pci_sdmmc"
+    ];
+    initrd.kernelModules = [];
+    kernelModules = ["kvm-intel"];
+    extraModulePackages = [];
+  };
 
   fileSystems."/" = {
     device = "/dev/disk/by-uuid/0aa2637b-5384-4b06-9ce8-6f9af350ba64";

--- a/nixos/hosts/snallygaster/hardware-configuration.nix
+++ b/nixos/hosts/snallygaster/hardware-configuration.nix
@@ -11,10 +11,12 @@
     (modulesPath + "/installer/scan/not-detected.nix")
   ];
 
-  boot.initrd.availableKernelModules = ["xhci_pci" "nvme" "usb_storage" "sd_mod" "rtsx_pci_sdmmc"];
-  boot.initrd.kernelModules = [];
-  boot.kernelModules = ["kvm-intel"];
-  boot.extraModulePackages = [];
+  boot = {
+    initrd.availableKernelModules = ["xhci_pci" "nvme" "usb_storage" "sd_mod" "rtsx_pci_sdmmc"];
+    initrd.kernelModules = [];
+    kernelModules = ["kvm-intel"];
+    extraModulePackages = [];
+  };
 
   fileSystems."/" = {
     device = "/dev/disk/by-uuid/df579f88-edf3-4d2d-9d99-da9b13e27b6b";

--- a/nixos/hosts/wendigo/hardware-configuration.nix
+++ b/nixos/hosts/wendigo/hardware-configuration.nix
@@ -11,16 +11,18 @@
     (modulesPath + "/installer/scan/not-detected.nix")
   ];
 
-  boot.initrd.availableKernelModules = [
-    "xhci_pci"
-    "nvme"
-    "usb_storage"
-    "sd_mod"
-    "rtsx_pci_sdmmc"
-  ];
-  boot.initrd.kernelModules = [];
-  boot.kernelModules = ["kvm-intel"];
-  boot.extraModulePackages = [];
+  boot = {
+    initrd.availableKernelModules = [
+      "xhci_pci"
+      "nvme"
+      "usb_storage"
+      "sd_mod"
+      "rtsx_pci_sdmmc"
+    ];
+    initrd.kernelModules = [];
+    kernelModules = ["kvm-intel"];
+    extraModulePackages = [];
+  };
 
   fileSystems."/" = {
     device = "/dev/disk/by-uuid/caeb6ce4-bcf6-44f0-9f52-31274ec33b02";

--- a/nixos/installer/configuration.nix
+++ b/nixos/installer/configuration.nix
@@ -31,21 +31,25 @@ in {
 
   # Override the empty initialHashedPassword set by installation-cd-minimal.nix
   # so the live session has a usable password for SSH access
-  users.users.nixos.initialHashedPassword = lib.mkForce null;
-  users.users.nixos.initialPassword = "nixos";
+  users.users.nixos = {
+    initialHashedPassword = lib.mkForce null;
+    initialPassword = "nixos";
+  };
 
-  environment.systemPackages = [bootstrapScript];
+  environment = {
+    systemPackages = [bootstrapScript];
 
-  # Bundle a read-only snapshot of the repo into the ISO.
-  # Available at /etc/nix-config for reference; nixos-install should still
-  # pull from GitHub after commits are pushed (or from a USB-mounted checkout).
-  environment.etc."nix-config".source = self;
+    # Bundle a read-only snapshot of the repo into the ISO.
+    # Available at /etc/nix-config for reference; nixos-install should still
+    # pull from GitHub after commits are pushed (or from a USB-mounted checkout).
+    etc."nix-config".source = self;
 
-  # Greet users with the bootstrap hint at login
-  environment.interactiveShellInit = ''
-    echo ""
-    echo "  NixOS Installer — to bootstrap a new host, run: nixos-bootstrap"
-    echo "  Repo snapshot available at: /etc/nix-config (read-only)"
-    echo ""
-  '';
+    # Greet users with the bootstrap hint at login
+    interactiveShellInit = ''
+      echo ""
+      echo "  NixOS Installer — to bootstrap a new host, run: nixos-bootstrap"
+      echo "  Repo snapshot available at: /etc/nix-config (read-only)"
+      echo ""
+    '';
+  };
 }

--- a/nixos/profiles/base.nix
+++ b/nixos/profiles/base.nix
@@ -15,90 +15,95 @@
     ../common/tailscale.nix
   ];
 
-  home-manager.useGlobalPkgs = true;
-  home-manager.useUserPackages = true;
-  home-manager.extraSpecialArgs = {inherit inputs;}; # pass flake inputs to home-manager
-  home-manager.backupFileExtension = "hm-bak"; # rename conflicts instead of failing
+  home-manager = {
+    useGlobalPkgs = true;
+    useUserPackages = true;
+    extraSpecialArgs = {inherit inputs;}; # pass flake inputs to home-manager
+    backupFileExtension = "hm-bak"; # rename conflicts instead of failing
+  };
 
   # Set your time zone.
   time.timeZone = "America/New_York";
 
   # Bootloader.
-  boot.loader.systemd-boot.enable = true;
-  boot.loader.efi.canTouchEfiVariables = true;
+  boot = {
+    loader = {
+      systemd-boot.enable = true;
+      efi.canTouchEfiVariables = true;
+    };
+    # Enable NFS for automounting
+    supportedFilesystems = ["nfs"];
+  };
 
   networking.networkmanager.enable = true;
 
-  # Enable NFS for automounting
-  boot.supportedFilesystems = ["nfs"];
-
   # Select internationalisation properties.
-  i18n.defaultLocale = "en_US.UTF-8";
-
-  i18n.extraLocaleSettings = {
-    LC_ADDRESS = "en_US.UTF-8";
-    LC_IDENTIFICATION = "en_US.UTF-8";
-    LC_MEASUREMENT = "en_US.UTF-8";
-    LC_MONETARY = "en_US.UTF-8";
-    LC_NAME = "en_US.UTF-8";
-    LC_NUMERIC = "en_US.UTF-8";
-    LC_PAPER = "en_US.UTF-8";
-    LC_TELEPHONE = "en_US.UTF-8";
-    LC_TIME = "en_US.UTF-8";
+  i18n = {
+    defaultLocale = "en_US.UTF-8";
+    extraLocaleSettings = {
+      LC_ADDRESS = "en_US.UTF-8";
+      LC_IDENTIFICATION = "en_US.UTF-8";
+      LC_MEASUREMENT = "en_US.UTF-8";
+      LC_MONETARY = "en_US.UTF-8";
+      LC_NAME = "en_US.UTF-8";
+      LC_NUMERIC = "en_US.UTF-8";
+      LC_PAPER = "en_US.UTF-8";
+      LC_TELEPHONE = "en_US.UTF-8";
+      LC_TIME = "en_US.UTF-8";
+    };
   };
 
   security.sudo.wheelNeedsPassword = false;
 
   users.defaultUserShell = pkgs.zsh;
-  programs.zsh.enable = true;
-  environment.pathsToLink = ["/share/zsh"]; # enable zsh completion for system packages
-  environment.shells = with pkgs; [
-    zsh
-  ];
 
   # Allow unfree packages
   nixpkgs.config.allowUnfree = true;
 
-  # List services that you want to enable:
-  services.envfs.enable = true;
-  services.prometheus.exporters.node.enable = true;
-  services.fwupd.enable = true;
+  services = {
+    envfs.enable = true;
+    prometheus.exporters.node.enable = true;
+    fwupd.enable = true;
+    tailscale.enable = lib.mkDefault true;
+    openssh = {
+      enable = lib.mkDefault true;
+      settings = {
+        PasswordAuthentication = false;
+        KbdInteractiveAuthentication = false;
+        PermitRootLogin = "no";
+      };
+      # Restrict to ed25519 only — removes weaker RSA/ECDSA/DSA host keys.
+      # NixOS generates this key automatically on first boot.
+      hostKeys = [
+        {
+          path = "/etc/ssh/ssh_host_ed25519_key";
+          type = "ed25519";
+        }
+      ];
+    };
+  };
 
   # Refresh fwupd metadata weekly; only on AC power to avoid draining battery.
   # Persistent=true ensures it runs on next boot if the scheduled time was missed.
-  systemd.timers.fwupd-refresh = {
-    wantedBy = ["timers.target"];
-    timerConfig = {
-      OnCalendar = "weekly";
-      Persistent = true;
-      RandomizedDelaySec = "2h";
-      ConditionACPower = true;
+  systemd = {
+    timers.fwupd-refresh = {
+      wantedBy = ["timers.target"];
+      timerConfig = {
+        OnCalendar = "weekly";
+        Persistent = true;
+        RandomizedDelaySec = "2h";
+        ConditionACPower = true;
+      };
+    };
+    services.fwupd-refresh = {
+      description = "Refresh fwupd metadata";
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = "${pkgs.fwupd}/bin/fwupdmgr refresh --force";
+      };
     };
   };
-  systemd.services.fwupd-refresh = {
-    description = "Refresh fwupd metadata";
-    serviceConfig = {
-      Type = "oneshot";
-      ExecStart = "${pkgs.fwupd}/bin/fwupdmgr refresh --force";
-    };
-  };
-  services.tailscale.enable = lib.mkDefault true;
-  services.openssh = {
-    enable = lib.mkDefault true;
-    settings = {
-      PasswordAuthentication = false;
-      KbdInteractiveAuthentication = false;
-      PermitRootLogin = "no";
-    };
-    # Restrict to ed25519 only — removes weaker RSA/ECDSA/DSA host keys.
-    # NixOS generates this key automatically on first boot.
-    hostKeys = [
-      {
-        path = "/etc/ssh/ssh_host_ed25519_key";
-        type = "ed25519";
-      }
-    ];
-  };
+
   # Enable Docker
   virtualisation.docker.enable = true;
 
@@ -113,19 +118,25 @@
     extra-trusted-public-keys = ["nix-config-grue.cachix.org-1:9VBdph98gMqkzdSO5mCh3ReESB3IbvyQ08jzT1fB1Q8="];
   };
 
-  programs.nh = {
-    enable = true;
-    clean.enable = true;
-    clean.extraArgs = lib.mkDefault "--keep-since 4d --keep 3";
+  programs = {
+    zsh.enable = true;
+    nh = {
+      enable = true;
+      clean.enable = true;
+      clean.extraArgs = lib.mkDefault "--keep-since 4d --keep 3";
+    };
+    nix-ld.enable = true;
   };
 
-  programs.nix-ld.enable = true;
-
-  environment.systemPackages = with pkgs; [
-    curl
-    git
-    rclone
-    wget
-    wireguard-tools
-  ];
+  environment = {
+    pathsToLink = ["/share/zsh"]; # enable zsh completion for system packages
+    shells = with pkgs; [zsh];
+    systemPackages = with pkgs; [
+      curl
+      git
+      rclone
+      wget
+      wireguard-tools
+    ];
+  };
 }

--- a/nixos/profiles/gaming.nix
+++ b/nixos/profiles/gaming.nix
@@ -1,5 +1,5 @@
 # nixos/profiles/gaming.nix
-{...}: {
+_: {
   programs.steam = {
     enable = true;
 

--- a/nixos/profiles/laptop/default.nix
+++ b/nixos/profiles/laptop/default.nix
@@ -1,37 +1,63 @@
 # nixos/profiles/laptop.nix
 {pkgs, ...}: {
-  #### Display server / desktop environment ####
-  services.xserver.enable = true;
+  services = {
+    #### Display server / desktop environment ####
+    xserver = {
+      enable = true;
+      xkb = {
+        layout = "us";
+        options = "caps:swapescape";
+        variant = "";
+      };
+    };
 
-  # Display manager
-  services.displayManager.sddm.enable = true;
+    # Display manager
+    displayManager.sddm.enable = true;
 
-  # Desktop environment (KDE Plasma 6)
-  services.desktopManager.plasma6.enable = true;
+    # Desktop environment (KDE Plasma 6)
+    desktopManager.plasma6.enable = true;
 
-  #### Optional desktop services ####
-  hardware.bluetooth.enable = true;
-  services.blueman.enable = true;
+    #### Optional desktop services ####
+    blueman.enable = true;
 
-  # Printing — both printers support IPP Everywhere (driverless IPP/Mopria);
-  # no host-side driver packages are needed.
-  services.printing.enable = true;
+    # Printing — both printers support IPP Everywhere (driverless IPP/Mopria);
+    # no host-side driver packages are needed.
+    printing = {
+      enable = true;
+      # auto-creates CUPS queues for discovered network printers (no manual lpadmin needed)
+      browsed.enable = true;
+    };
 
-  # mDNS/Bonjour — auto-discovers network printers advertising via DNS-SD
-  services.avahi = {
-    enable = true;
-    nssmdns4 = true; # allows resolving .local hostnames for printer discovery
-    openFirewall = true; # opens UDP 5353 for mDNS; intentional for LAN printer discovery
+    # mDNS/Bonjour — auto-discovers network printers advertising via DNS-SD
+    avahi = {
+      enable = true;
+      nssmdns4 = true; # allows resolving .local hostnames for printer discovery
+      openFirewall = true; # opens UDP 5353 for mDNS; intentional for LAN printer discovery
+    };
+
+    #### VPN ####
+    mullvad-vpn = {
+      enable = true;
+      package = pkgs.mullvad-vpn; # includes GUI + CLI (default is CLI-only pkgs.mullvad)
+      enableEarlyBootBlocking = true; # block traffic before network stack initializes, preventing boot-time leaks
+    };
+
+    # Grant the active console user access to the PC speaker evdev node without
+    # adding them to the broad `input` group (which would expose all input devices).
+    udev.extraRules = ''
+      SUBSYSTEM=="input", ATTRS{name}=="PC Speaker", TAG+="uaccess"
+    '';
   };
 
-  # auto-creates CUPS queues for discovered network printers (no manual lpadmin needed)
-  services.printing.browsed.enable = true;
+  hardware.bluetooth.enable = true;
 
   # cups-browsed has a race condition on first boot: it may start before Avahi
   # has fully resolved .local hostnames, leaving queues with no destination.
   # Explicitly ordering it after avahi-daemon.service prevents this.
-  systemd.services.cups-browsed.after = ["avahi-daemon.service"];
-  systemd.services.cups-browsed.requires = ["avahi-daemon.service"];
+  systemd.services.cups-browsed = {
+    after = ["avahi-daemon.service"];
+    requires = ["avahi-daemon.service"];
+  };
 
   #### Desktop-related system packages ####
   environment.systemPackages = with pkgs; [
@@ -42,28 +68,18 @@
   ];
 
   #### XDG integration ####
-  xdg.portal.enable = true;
-  xdg.portal.extraPortals = with pkgs; [
-    xdg-desktop-portal-gtk
-  ];
+  xdg.portal = {
+    enable = true;
+    extraPortals = with pkgs; [
+      xdg-desktop-portal-gtk
+    ];
+  };
 
   #### Fonts, input, and editor ####
   fonts.packages = with pkgs; [
     fira-code
     roboto-mono
   ];
-
-  services.xserver.xkb = {
-    layout = "us";
-    options = "caps:swapescape";
-    variant = "";
-  };
-
-  # Grant the active console user access to the PC speaker evdev node without
-  # adding them to the broad `input` group (which would expose all input devices).
-  services.udev.extraRules = ''
-    SUBSYSTEM=="input", ATTRS{name}=="PC Speaker", TAG+="uaccess"
-  '';
 
   programs.vim = {
     enable = true;

--- a/nixos/profiles/laptop/power.nix
+++ b/nixos/profiles/laptop/power.nix
@@ -3,49 +3,51 @@
 # TLP and power-profiles-daemon are mutually exclusive; KDE Plasma enables PPD
 # by default, so we explicitly disable it here.
 {lib, ...}: {
-  services.power-profiles-daemon.enable = lib.mkForce false;
+  services = {
+    power-profiles-daemon.enable = lib.mkForce false;
 
-  services.tlp = {
-    enable = true;
-    settings = {
-      # CPU scaling governor and energy/performance policy
-      CPU_SCALING_GOVERNOR_ON_AC = "performance";
-      CPU_SCALING_GOVERNOR_ON_BAT = "schedutil";
-      CPU_ENERGY_PERF_POLICY_ON_AC = "balance_performance";
-      CPU_ENERGY_PERF_POLICY_ON_BAT = "balance_power";
+    tlp = {
+      enable = true;
+      settings = {
+        # CPU scaling governor and energy/performance policy
+        CPU_SCALING_GOVERNOR_ON_AC = "performance";
+        CPU_SCALING_GOVERNOR_ON_BAT = "schedutil";
+        CPU_ENERGY_PERF_POLICY_ON_AC = "balance_performance";
+        CPU_ENERGY_PERF_POLICY_ON_BAT = "balance_power";
 
-      # Turbo boost: always on; EPP/governor manage the power/perf tradeoff
-      CPU_BOOST_ON_AC = 1;
-      CPU_BOOST_ON_BAT = 1;
+        # Turbo boost: always on; EPP/governor manage the power/perf tradeoff
+        CPU_BOOST_ON_AC = 1;
+        CPU_BOOST_ON_BAT = 1;
 
-      # Platform profiles (Intel Mode 2 power management)
-      PLATFORM_PROFILE_ON_AC = "balanced";
-      PLATFORM_PROFILE_ON_BAT = "balanced";
+        # Platform profiles (Intel Mode 2 power management)
+        PLATFORM_PROFILE_ON_AC = "balanced";
+        PLATFORM_PROFILE_ON_BAT = "balanced";
 
-      # NVMe power saving
-      PCIE_ASPM_ON_AC = "default";
-      PCIE_ASPM_ON_BAT = "powersupersave";
+        # NVMe power saving
+        PCIE_ASPM_ON_AC = "default";
+        PCIE_ASPM_ON_BAT = "powersupersave";
 
-      # WiFi power saving (Intel AX201)
-      WIFI_PWR_ON_AC = "off";
-      WIFI_PWR_ON_BAT = "on";
+        # WiFi power saving (Intel AX201)
+        WIFI_PWR_ON_AC = "off";
+        WIFI_PWR_ON_BAT = "on";
 
-      # Runtime power management for USB and PCI devices
-      RUNTIME_PM_ON_AC = "on";
-      RUNTIME_PM_ON_BAT = "auto";
+        # Runtime power management for USB and PCI devices
+        RUNTIME_PM_ON_AC = "on";
+        RUNTIME_PM_ON_BAT = "auto";
 
-      # These limits apply via ThinkPad ACPI and are preserved across reboots.
-      START_CHARGE_THRESH_BAT0 = 70;
-      STOP_CHARGE_THRESH_BAT0 = 80;
+        # These limits apply via ThinkPad ACPI and are preserved across reboots.
+        START_CHARGE_THRESH_BAT0 = 70;
+        STOP_CHARGE_THRESH_BAT0 = 80;
+      };
     };
-  };
 
-  services.logind.settings.Login = {
-    HandleLidSwitch = "suspend";
-    HandleLidSwitchExternalPower = "ignore";
-    HandleLidSwitchDocked = "ignore";
-    HandlePowerKey = "suspend";
-    IdleAction = "suspend";
-    IdleActionSec = "300";
+    logind.settings.Login = {
+      HandleLidSwitch = "suspend";
+      HandleLidSwitchExternalPower = "ignore";
+      HandleLidSwitchDocked = "ignore";
+      HandlePowerKey = "suspend";
+      IdleAction = "suspend";
+      IdleActionSec = "300";
+    };
   };
 }

--- a/nixos/profiles/laptop/power.nix
+++ b/nixos/profiles/laptop/power.nix
@@ -40,10 +40,10 @@
     };
   };
 
-  # Suspend on lid close regardless of power state
   services.logind.settings.Login = {
     HandleLidSwitch = "suspend";
-    HandleLidSwitchExternalPower = "suspend";
+    HandleLidSwitchExternalPower = "ignore";
+    HandleLidSwitchDocked = "ignore";
     HandlePowerKey = "suspend";
     IdleAction = "suspend";
     IdleActionSec = "300";

--- a/nixos/profiles/server.nix
+++ b/nixos/profiles/server.nix
@@ -19,9 +19,11 @@
   };
 
   # CUPS print server — serve printers to the network via mDNS/Bonjour
-  services.printing.enable = true;
-  services.avahi = {
-    enable = true;
-    nssmdns4 = true;
+  services = {
+    printing.enable = true;
+    avahi = {
+      enable = true;
+      nssmdns4 = true;
+    };
   };
 }


### PR DESCRIPTION
This pull request includes several updates to the Nix configuration and related project files, focusing on improving configuration clarity, expanding language and tool support, and streamlining module definitions. The most significant changes are grouped below.

**Project and Tooling Configuration Improvements:**

* Expanded the list of supported languages in `.serena/project.yml` and updated comments to provide more accurate and current guidance for language server configuration.
* Simplified tool inclusion/exclusion documentation in `.serena/project.yml` by replacing the static tool list with a link to the official documentation, and added similar links for other tool-related settings.
* Clarified the behavior and override mechanism for project modes in `.serena/project.yml`, including new documentation and the addition of `added_modes` and `additional_workspace_folders` settings for more flexible project configuration. [[1]](diffhunk://#diff-fd53d15bc16f79894e36155c602091255f9f945f7097c34ba130953421f2ad84L125-R101) [[2]](diffhunk://#diff-fd53d15bc16f79894e36155c602091255f9f945f7097c34ba130953421f2ad84R125-R140)
* Added `"WebSearch"` to the list of allowed commands in `.claude/settings.local.json`, enabling web search capabilities for Claude.

**Home-Manager/Nix Module Refactoring and Enhancements:**

* Refactored multiple Home-Manager module definitions to use a consistent argument style (`_: { ... }` instead of `{...}: { ... }`) for improved readability and maintainability. [[1]](diffhunk://#diff-d16b97fa66cc74f33781a26b201971f48fbf18b341f4a738726b53bbbdb39a52L1-R1) [[2]](diffhunk://#diff-8fc9fc275e3c1a90cc37a8b03dd60b740acab28c4b8d4ffd6566227dd75b6678L1-R1) [[3]](diffhunk://#diff-1817f40a88f93cc7af844e7006787de4d7a5b9bbc3b1ef2d7042e83b454a0c24L1-R1) [[4]](diffhunk://#diff-ea2a4ead307e478038b3ba899ff7dc8b9420c91e7fbe3e69abf7003f21bdd7a5L1-R1) [[5]](diffhunk://#diff-eb5e5efb8373e64d3a25d4f8c6912b40068f76158b3251aa36f680cb4e83ad2fL1-R1) [[6]](diffhunk://#diff-bf3568d1570cb6fc5acf15521a1f372ea387ba8c00d29e532d1e7a6525611e30L1-R1) [[7]](diffhunk://#diff-0a4319459e5622d178f262ca9e72f268e91725e157191e26cc99298a935a0d4eL1-R1) [[8]](diffhunk://#diff-33af1e44a8ab877db1c465fccfa913bf040e43196b7628cec8e05b1a06df358eL1-R1) [[9]](diffhunk://#diff-4128d38accb65741bc7b9d0546adfd29261b8f60f74918d5cab7c279d25c745bL2-R2) [[10]](diffhunk://#diff-9aa159f1157bc849d9d48df70ebeed7371ec8ad9645b57d0662a0f342f0c2d70L2-R2)
* Updated the 1Password and Signal modules to use `autostart` desktop entries for automatic startup, replacing the previous systemd user service for 1Password and adding a new module for Signal. [[1]](diffhunk://#diff-1950fccc0dbc9287f41e13fa594ef816f274416686e14cf496dc3639eb048bbcL2-R8) [[2]](diffhunk://#diff-a63f6c1187748687ed6d19f82a531ab99687d7e33f88dc1ebe2ce79b927a2dd4R1-R11)
* Improved the SSH, Git, and Jujutsu configuration structure in `home/modules/ssh/default.nix` by nesting settings under a unified `programs` attribute and consolidating match block definitions.
* Adjusted the Kitty font configuration to use an attribute set, improving clarity and extensibility.

**Quality-of-Life and Usability Updates:**

* Added a Neovim keymap to toggle LSP inlay hints, enhancing developer experience.
* Set `includeGitInstructions = false` in the Claude module configuration, disabling automatic inclusion of Git instructions.
* Minor fix in `flake.nix` to use `_` instead of `{...}` for a NixOS module argument, aligning with best practices.

**Home Role and Package Management:**

* Refactored `home/roles/base.nix` to use the `programs` and `home` attribute sets for enabling Home-Manager features and managing packages, and moved Signal installation to its own module. [[1]](diffhunk://#diff-aecb6c5219f80a0542b3c143609e8563410e5289802f99c14e98419fb2359e64R29-R46) [[2]](diffhunk://#diff-aecb6c5219f80a0542b3c143609e8563410e5289802f99c14e98419fb2359e64L56-R69)