### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,11 +54,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1778274803,
-        "narHash": "sha256-a3a/7mXXaDssIhHrTkHsjoV0h/qL3yWJXmpD1P18bEg=",
+        "lastModified": 1778299984,
+        "narHash": "sha256-2F8TLwYotqAlLAjw6TuGWzg79thp5Al2cn7BFoWq8iA=",
         "owner": "charmbracelet",
         "repo": "nur",
-        "rev": "0300425a233287e5fddcf9795968e47222c5ce49",
+        "rev": "a177145aae418aaabc40819dbd8aac17a1048f1c",
         "type": "github"
       },
       "original": {
@@ -255,11 +255,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778248595,
-        "narHash": "sha256-dhFgEjoeJMYN/7OY6xfxS799YB4IjbbYXTjyGIJyLpc=",
+        "lastModified": 1778365864,
+        "narHash": "sha256-ImoT/wqmgMImf2dAC+E0MverAdA4QXsedOeES9B7Ezw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fdb2ccba9d5e1238d32e0c4a3ec1a277efa80c1d",
+        "rev": "2f419037039a152448c5f4ae9494154753d1b399",
         "type": "github"
       },
       "original": {
@@ -294,11 +294,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778240325,
-        "narHash": "sha256-d2HIS7LpfI0lgxiXCXLjxrHl3eIdNvAVexOu0xiM488=",
+        "lastModified": 1778393439,
+        "narHash": "sha256-mOtQxUjtKaPHLeoLOY/YEDctmud1X9KwJr4kE1MJ3Wc=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "dd2d0e3f6ba00af01b9498f5697173bdc2524bee",
+        "rev": "01466c414c7357ae2ce32be4a272a7c69e94ab5f",
         "type": "github"
       },
       "original": {
@@ -397,11 +397,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1778124196,
-        "narHash": "sha256-pYEytCNic/czazbV9r3tbQ6BZzqRBg/41x2dIC5ymOo=",
+        "lastModified": 1778274207,
+        "narHash": "sha256-I4puXmX1iovcCHZlRmztO3vW0mAbbRvq4F8wgIMQ1MM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "68a8af93ff4297686cb68880845e61e5e2e41d92",
+        "rev": "b3da656039dc7a6240f27b2ef8cc6a3ef3bccae7",
         "type": "github"
       },
       "original": {
@@ -433,11 +433,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1778285060,
-        "narHash": "sha256-kti9S5YVuAKG78KQBsGkTvFiIsOJrjuouogqcd1foyM=",
+        "lastModified": 1778400298,
+        "narHash": "sha256-EbzaBJOXoL8x+ej2Nb4ecLhzeaukeDqENgKncRf5GJY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e27df49d002b1f0d560a4d80ccf2e6cc3bc7a008",
+        "rev": "c2033872e1c755245118f72f9e6ea2f8530593ae",
         "type": "github"
       },
       "original": {
@@ -572,11 +572,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1778234906,
-        "narHash": "sha256-GiiBEIt1R6Ke93XYx3sKyMO9l+J5zJ5kk5IVkAv0nvY=",
+        "lastModified": 1778341752,
+        "narHash": "sha256-x+xrfVafQkeI7sLg7J8boEK2MBPu3UvW35tzYARSxlU=",
         "owner": "oraios",
         "repo": "serena",
-        "rev": "ab98ea676253e7a4efee7bc9f9aa7caf51cc6c52",
+        "rev": "249f6b07f9ccac259b0ff95e06c9a40629748e17",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated update of `flake.lock` inputs.

All hosts built successfully against this lock file.
Merging will trigger `autodeploy.yaml`, which publishes store paths for pickup by `nixos-autodeploy`.

## Package changes

**Added: 0
0 | Removed: 0
0 | Changed: **

<details>
<summary>Full diff</summary>

```
akonadi-calendar: 26.04.0 → 26.04.1
akonadi-contacts: 26.04.0 → 26.04.1
akonadi-mime: 26.04.0 → 26.04.1
akonadi-search: 26.04.0 → 26.04.1
akonadi: 26.04.0 → 26.04.1
ark: 26.04.0 → 26.04.1
attica: 6.25.0 → 6.26.0
baloo-widgets: 26.04.0 → 26.04.1
baloo: 6.25.0 → 6.26.0, [31;1m34.1 KiB[0m
bluez-qt: 6.25.0 → 6.26.0
breeze-icons: 6.25.0 → 6.26.0
claude-code: 2.1.128 → 2.1.133, [32;1m-18.2 MiB[0m
dolphin-plugins: 26.04.0 → 26.04.1
dolphin: 26.04.0 → 26.04.1, [31;1m10.0 KiB[0m
elisa: 26.04.0 → 26.04.1
ffmpegthumbs: 26.04.0 → 26.04.1
firefox-unwrapped: 150.0.1 → 150.0.2, [31;1m169.2 KiB[0m
firefox: 150.0.1 → 150.0.2, [31;1m55.2 KiB[0m
frameworkintegration: 6.25.0 → 6.26.0
freerdp: 3.24.2 → 3.26.0, [31;1m41.2 KiB[0m
grantleetheme: 26.04.0 → 26.04.1
gwenview: 26.04.0 → 26.04.1, [31;1m59.6 KiB[0m
index-x86_64: [31;1m465.9 KiB[0m
initrd-linux: 6.18.26 → 6.18.28, [31;1m41.5 KiB[0m
initrd-linux: 6.18.26 → 6.18.28, [31;1m8.6 KiB[0m
initrd-linux: 6.18.26 → 6.18.28, [32;1m-25.0 KiB[0m
jjui: [31;1m16.0 KiB[0m
jujutsu: 0.40.0 → 0.41.0, [31;1m532.4 KiB[0m
kaccounts-integration: 26.04.0 → 26.04.1
karchive: 6.25.0 → 6.26.0
kate: 26.04.0 → 26.04.1
kauth: 6.25.0 → 6.26.0
kbookmarks: 6.25.0 → 6.26.0
kcalendarcore: 6.25.0 → 6.26.0
kcalutils: 26.04.0 → 26.04.1
kcmutils: 6.25.0 → 6.26.0
kcodecs: 6.25.0 → 6.26.0
kcolorscheme: 6.25.0 → 6.26.0
kcompletion: 6.25.0 → 6.26.0
kconfig: 6.25.0 → 6.26.0
kconfigwidgets: 6.25.0 → 6.26.0
kcontacts: 6.25.0 → 6.26.0
kcoreaddons: 6.25.0 → 6.26.0, [31;1m91.0 KiB[0m
kcrash: 6.25.0 → 6.26.0
kdav: 6.25.0 → 6.26.0
kdbusaddons: 6.25.0 → 6.26.0
kde-inotify-survey: 26.04.0 → 26.04.1
kdeclarative: 6.25.0 → 6.26.0
kded: 5.116.0, 6.25.0 → 6.26.0, [32;1m-189.5 KiB[0m
kdegraphics-mobipocket: 26.04.0 → 26.04.1
kdegraphics-thumbnailers: 26.04.0 → 26.04.1
kdepim-runtime: 26.04.0 → 26.04.1
kdesu: 6.25.0 → 6.26.0
kdnssd: 6.25.0 → 6.26.0
kdoctools: 6.25.0 → 6.26.0
kfilemetadata: 6.25.0 → 6.26.0
kglobalaccel: 6.25.0 → 6.26.0
kguiaddons: 6.25.0 → 6.26.0
khelpcenter: 26.04.0 → 26.04.1
kholidays: 6.25.0 → 6.26.0, [31;1m106.1 KiB[0m
ki18n: 6.25.0 → 6.26.0
kiconthemes: 6.25.0 → 6.26.0
kidentitymanagement: 26.04.0 → 26.04.1
kidletime: 6.25.0 → 6.26.0
kimageformats: 6.25.0 → 6.26.0, [31;1m145.5 KiB[0m
kimap: 26.04.0 → 26.04.1
kio-admin: 26.04.0 → 26.04.1
kio-extras-kf5: [32;1m-66.4 KiB[0m
kio-extras: 26.04.0 → 26.04.1, [31;1m13.0 KiB[0m
kio: 6.25.0 → 6.26.0, [32;1m-29.9 KiB[0m
kirigami2: [32;1m-27.2 KiB[0m
kirigami: 6.25.0 → 6.26.0, [31;1m1.1 MiB[0m
kitemmodels: 6.25.0 → 6.26.0
kitemviews: 6.25.0 → 6.26.0
kjobwidgets: 6.25.0 → 6.26.0, [32;1m-9.8 KiB[0m
kldap: 26.04.0 → 26.04.1
kmailtransport: 26.04.0 → 26.04.1, [31;1m10.4 KiB[0m
kmbox: 26.04.0 → 26.04.1
kmime: 26.04.0 → 26.04.1
knewstuff: 6.25.0 → 6.26.0
knotifications: 6.25.0 → 6.26.0
knotifyconfig: 6.25.0 → 6.26.0
konsole: 26.04.0 → 26.04.1
kpackage: 6.25.0 → 6.26.0, [32;1m-191.6 KiB[0m
kparts: 6.25.0 → 6.26.0
kpimtextedit: 26.04.0 → 26.04.1
kpty: 6.25.0 → 6.26.0
kquickcharts: 6.25.0 → 6.26.0
krunner: 6.25.0 → 6.26.0
kservice: 6.25.0 → 6.26.0
ksmtp: 26.04.0 → 26.04.1
kstatusnotifieritem: 6.25.0 → 6.26.0
ksvg: 6.25.0 → 6.26.0
ktexteditor: 6.25.0 → 6.26.0, [31;1m8.8 KiB[0m
ktexttemplate: 6.25.0 → 6.26.0
ktextwidgets: 6.25.0 → 6.26.0
kunifiedpush: 26.04.0 → 26.04.1
kunitconversion: 6.25.0 → 6.26.0, [31;1m8.7 KiB[0m
kuserfeedback: 6.25.0 → 6.26.0, [31;1m12.0 KiB[0m
kwallet: 6.25.0 → 6.26.0, [32;1m-928.2 KiB[0m
kwalletmanager: 26.04.0 → 26.04.1
kwidgetsaddons: 6.25.0 → 6.26.0
kwindowsystem: 6.25.0 → 6.26.0
kxmlgui: 6.25.0 → 6.26.0
libgravatar: 26.04.0 → 26.04.1
libinput: 1.29.2 → 1.31.1, [31;1m45.2 KiB[0m
libkdcraw: 26.04.0 → 26.04.1
libkdepim: 26.04.0 → 26.04.1
libkexiv2: 26.04.0 → 26.04.1
libkgapi: 26.04.0 → 26.04.1, [31;1m14.0 KiB[0m
libkleo: 26.04.0 → 26.04.1
libplasma: [31;1m12.9 KiB[0m
linux: 6.18.26 → 6.18.28, [31;1m32.0 KiB[0m
mesa: 26.0.6 → 26.1.0, [31;1m11.9 MiB[0m
mesa: 26.0.6 → 26.1.0, [31;1m24.0 MiB[0m
messagelib: 26.04.0 → 26.04.1
modemmanager-qt: 6.25.0 → 6.26.0
networkmanager-qt: 6.25.0 → 6.26.0
nixos-manual: [31;1m31.7 KiB[0m
nixos-system-kushtaka: 26.05.20260507.68a8af9 → 26.05.20260508.b3da656
nixos-system-snallygaster: 26.05.20260507.68a8af9 → 26.05.20260508.b3da656
nixos-system-wendigo: 26.05.20260507.68a8af9 → 26.05.20260508.b3da656
okular: 26.04.0 → 26.04.1
phonon: 4.11.1 → ∅, [32;1m-1.4 MiB[0m
pimcommon: 26.04.0 → 26.04.1
prison: 6.25.0 → 6.26.0
purpose: 6.25.0 → 6.26.0, [31;1m290.2 KiB[0m
qqc2-desktop-style: 6.25.0 → 6.26.0
qrca: 26.04.0 → 26.04.1
serena-agent: [31;1m24.2 KiB[0m
solid: 6.25.0 → 6.26.0, [31;1m220.3 KiB[0m
sonnet: 6.25.0 → 6.26.0, [32;1m-80.2 KiB[0m
source: [31;1m199.6 KiB[0m
syndication: 6.25.0 → 6.26.0
syntax-highlighting: 6.25.0 → 6.26.0, [31;1m8.4 KiB[0m
tailscale: 1.96.5 → 1.98.0, [31;1m650.0 KiB[0m
threadweaver: 6.25.0 → 6.26.0
x86_energy_perf_policy: 6.18.26 → 6.18.28
```

</details>