### PR TITLE
Disable Atuin up arrow feature

### DIFF
--- a/home/modules/atuin/default.nix
+++ b/home/modules/atuin/default.nix
@@ -1,6 +1,7 @@
 _: {
   programs.atuin = {
     enable = true;
+    flags = ["--disable-up-arrow"];
     settings = {
       ai.enabled = true;
 


### PR DESCRIPTION
This pull request introduces a minor configuration update for the `atuin` program. Specifically, it adds the `--disable-up-arrow` flag to the program's settings to modify its behavior.

- Added the `--disable-up-arrow` flag to the `programs.atuin` configuration in `home/modules/atuin/default.nix`.