### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,11 +54,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1778299984,
-        "narHash": "sha256-2F8TLwYotqAlLAjw6TuGWzg79thp5Al2cn7BFoWq8iA=",
+        "lastModified": 1778592663,
+        "narHash": "sha256-ABPyLpmf9T/sJpZw0xQrBBzbX9wmCldtlXGxCeikRzw=",
         "owner": "charmbracelet",
         "repo": "nur",
-        "rev": "a177145aae418aaabc40819dbd8aac17a1048f1c",
+        "rev": "5639c4113430b20d744c57f525ff406ecc4040df",
         "type": "github"
       },
       "original": {
@@ -255,11 +255,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778365864,
-        "narHash": "sha256-ImoT/wqmgMImf2dAC+E0MverAdA4QXsedOeES9B7Ezw=",
+        "lastModified": 1778628724,
+        "narHash": "sha256-VNG6hJ146VEenXcDrB3t6MVnrMx+gtyCWTCDkzOp9Qs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2f419037039a152448c5f4ae9494154753d1b399",
+        "rev": "6a0bbd6b4720da1c9ce7ebf35ff5c41a82db367a",
         "type": "github"
       },
       "original": {
@@ -333,11 +333,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1778143761,
-        "narHash": "sha256-lkesY6x2X2qxlqLM7CT2iM/0rP2JB7fruPN3h8POXmI=",
+        "lastModified": 1778593042,
+        "narHash": "sha256-xYGrSg6354UK2K4WSQd4+TfyvfqmvFbSY+ZtGQUXK0c=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "3bcaa367d4c550d687a17ac792fd5cda214ee871",
+        "rev": "9bd7c80d43e258aaa607d83b43661df11444d808",
         "type": "github"
       },
       "original": {
@@ -397,11 +397,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1778274207,
-        "narHash": "sha256-I4puXmX1iovcCHZlRmztO3vW0mAbbRvq4F8wgIMQ1MM=",
+        "lastModified": 1778580735,
+        "narHash": "sha256-t+8AVV8ExvOmslz2sLIgw/hJBKlyl65rJvxjvvjHgpE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b3da656039dc7a6240f27b2ef8cc6a3ef3bccae7",
+        "rev": "48d91f2c0ce7b9e589f967d4f685153dd765dcdd",
         "type": "github"
       },
       "original": {
@@ -413,11 +413,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1777954456,
-        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "lastModified": 1778443072,
+        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
         "type": "github"
       },
       "original": {
@@ -433,11 +433,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1778400298,
-        "narHash": "sha256-EbzaBJOXoL8x+ej2Nb4ecLhzeaukeDqENgKncRf5GJY=",
+        "lastModified": 1778660370,
+        "narHash": "sha256-EkZaUJrp+o0tWHWxokgHKVbM8I0VCg9W4byEAZhS1sg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c2033872e1c755245118f72f9e6ea2f8530593ae",
+        "rev": "967b2ceaf522a8f2eb26d284d7a233581ed21baf",
         "type": "github"
       },
       "original": {
@@ -572,11 +572,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1778341752,
-        "narHash": "sha256-x+xrfVafQkeI7sLg7J8boEK2MBPu3UvW35tzYARSxlU=",
+        "lastModified": 1778600324,
+        "narHash": "sha256-CQPcbLzn4NXRqTZvik5Tzf1McyzxZatQDRrALJX8mnU=",
         "owner": "oraios",
         "repo": "serena",
-        "rev": "249f6b07f9ccac259b0ff95e06c9a40629748e17",
+        "rev": "70d939739a3b1e85ab76c880c41a1b43e2c62730",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated update of `flake.lock` inputs.

All hosts built successfully against this lock file.
Merging will trigger `autodeploy.yaml`, which publishes store paths for pickup by `nixos-autodeploy`.

## Package changes

**Added: 0
0 | Removed: 0
0 | Changed: **

<details>
<summary>Full diff</summary>

```
aws-sdk-cpp: 1.11.647 → ∅, [32;1m-7.8 MiB[0m
claude-code: 2.1.133 → 2.1.138, [31;1m856.0 KiB[0m
crush: 0.66.1 → 0.67.0, [31;1m73.4 KiB[0m
dnsmasq: 2.92 → 2.92rel2
initrd-linux: 6.18.28 → 6.18.29
initrd-linux: 6.18.28 → 6.18.29, [32;1m-32.9 KiB[0m
initrd-linux: 6.18.28 → 6.18.29, [32;1m-68.5 KiB[0m
intel-compute-runtime-legacy1: [32;1m-72.0 KiB[0m
intel-graphics-compiler: 2.30.1 → 2.34.4, [31;1m641.9 KiB[0m
jjui: 0.10.4 → 0.10.5
just: 1.50.0 → 1.51.0, [31;1m30.7 KiB[0m
libgit2: 1.9.2 → 1.9.3
linux: 6.18.28 → 6.18.29, [31;1m8.7 KiB[0m
mullvad-vpn: 2026.1 → 2026.2, [32;1m-1.3 MiB[0m
nix-cmd: 2.30.5+1 → ∅, [32;1m-967.7 KiB[0m
nix-expr: 2.30.5+1 → ∅, [32;1m-2.8 MiB[0m
nix-fetchers: 2.30.5+1 → ∅, [32;1m-1.3 MiB[0m
nix-flake: 2.30.5+1 → ∅, [32;1m-939.0 KiB[0m
nix-main: 2.30.5+1 → ∅, [32;1m-370.5 KiB[0m
nix-store: 2.30.5+1 → ∅, [32;1m-4.8 MiB[0m
nix-util: 2.30.5+1 → ∅, [32;1m-1.9 MiB[0m
nixd: 2.9.0 → 2.9.1, [31;1m28.8 KiB[0m
nixf: 2.9.0 → 2.9.1
nixos-manual: [31;1m8.8 KiB[0m
nixos-system-kushtaka: 26.05.20260508.b3da656 → 26.05.20260512.48d91f2
nixos-system-snallygaster: 26.05.20260508.b3da656 → 26.05.20260512.48d91f2
nixos-system-wendigo: 26.05.20260508.b3da656 → 26.05.20260512.48d91f2
nixt: 2.9.0 → 2.9.1
serena-agent: 1.2.0 → 1.3.1.dev0, [31;1m33.8 KiB[0m
source: [31;1m283.9 KiB[0m
uriparser: 1.0.1 → 1.0.2
urllib3: 2.6.3 → 2.7.0
x86_energy_perf_policy: 6.18.28 → 6.18.29
```

</details>