### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,11 +54,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1778592663,
-        "narHash": "sha256-ABPyLpmf9T/sJpZw0xQrBBzbX9wmCldtlXGxCeikRzw=",
+        "lastModified": 1778877118,
+        "narHash": "sha256-rgd8VD4cQyZNtYixSyS9nZeuGSGLfGWGcK292QfNXmk=",
         "owner": "charmbracelet",
         "repo": "nur",
-        "rev": "5639c4113430b20d744c57f525ff406ecc4040df",
+        "rev": "30e40cd8f76bfe6ce4a9bb79446a9222cfa63c76",
         "type": "github"
       },
       "original": {
@@ -255,11 +255,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778628724,
-        "narHash": "sha256-VNG6hJ146VEenXcDrB3t6MVnrMx+gtyCWTCDkzOp9Qs=",
+        "lastModified": 1778916285,
+        "narHash": "sha256-lW6J9Qorll5K+Xhvhm1UA58JI34QidOmeUnz7MzLu8U=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6a0bbd6b4720da1c9ce7ebf35ff5c41a82db367a",
+        "rev": "1772e8fb838e26f9b0f07bcbc5118c62af314d85",
         "type": "github"
       },
       "original": {
@@ -397,11 +397,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1778580735,
-        "narHash": "sha256-t+8AVV8ExvOmslz2sLIgw/hJBKlyl65rJvxjvvjHgpE=",
+        "lastModified": 1778794387,
+        "narHash": "sha256-BL04pOS9453Awkeb9f90XBJXBSkWxN+vB7HIgnL0iMM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "48d91f2c0ce7b9e589f967d4f685153dd765dcdd",
+        "rev": "8a1b0127302ea51e05bf4ea5a291743fac442406",
         "type": "github"
       },
       "original": {
@@ -433,11 +433,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1778660370,
-        "narHash": "sha256-EkZaUJrp+o0tWHWxokgHKVbM8I0VCg9W4byEAZhS1sg=",
+        "lastModified": 1778920199,
+        "narHash": "sha256-vj3eiu8Zvn8DEtWcJH1ewMrbK2kZGTE5LFnamDR3AeI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "967b2ceaf522a8f2eb26d284d7a233581ed21baf",
+        "rev": "2ac250ba9a6782c67cd01073ce4271f9839966f4",
         "type": "github"
       },
       "original": {
@@ -572,11 +572,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1778600324,
-        "narHash": "sha256-CQPcbLzn4NXRqTZvik5Tzf1McyzxZatQDRrALJX8mnU=",
+        "lastModified": 1778789026,
+        "narHash": "sha256-L/lRtEqnCtzCJjKEuasGm75czkG0sqMKp2Gj8u2Ekfk=",
         "owner": "oraios",
         "repo": "serena",
-        "rev": "70d939739a3b1e85ab76c880c41a1b43e2c62730",
+        "rev": "1767a259ceee2fbf1f6857f110b453c762fe05af",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated update of `flake.lock` inputs.

All hosts built successfully against this lock file.
Merging will trigger `autodeploy.yaml`, which publishes store paths for pickup by `nixos-autodeploy`.

## Package changes

**Added: 2 | Removed: 4 | Changed: 88**

<details>
<summary>Full diff</summary>

```
aurorae: 6.6.4 → 6.6.5
bluedevil: 6.6.4 → 6.6.5, [31;1m10.7 KiB[0m
breeze-gtk: 6.6.4 → 6.6.5
breeze: 6.6.4, 6.6.4-qt5 → 6.6.5, 6.6.5-qt5
claude-code: 2.1.138 → 2.1.140, [31;1m976.0 KiB[0m
crush: 0.67.0 → 0.69.1, [31;1m232.8 KiB[0m
discord-stage: ∅ → ε
discord: 0.0.134 → 1.0.137, [31;1m293.6 MiB[0m
discover: 6.6.4 → 6.6.5, [31;1m33.2 KiB[0m
docker-containerd: 29.4.2 → 29.4.3
docker-runc: 29.4.2 → 29.4.3
docker-tini: 29.4.2 → 29.4.3
docker: 29.4.2 → 29.4.3
drkonqi: 6.6.4 → 6.6.5, [31;1m16.8 KiB[0m
errcheck: 1.10.0 → 1.20.0, [31;1m33.8 KiB[0m
firefox-unwrapped: 150.0.2 → 150.0.3, [31;1m99.3 KiB[0m
firefox: 150.0.2 → 150.0.3, [32;1m-56.8 KiB[0m
gh-dash: 4.23.2 → 4.24.0, [31;1m952.2 KiB[0m
home-configuration-reference: [31;1m9.9 KiB[0m
initrd-linux: 6.18.29 → 6.18.30, [31;1m171.5 KiB[0m
initrd-linux: 6.18.29 → 6.18.30, [31;1m176.4 KiB[0m
initrd-linux: 6.18.29 → 6.18.30, [31;1m227.6 KiB[0m
kactivitymanagerd: 6.6.4 → 6.6.5
kde-cli-tools: 6.6.4 → 6.6.5
kde-gtk-config: 6.6.4 → 6.6.5
kdecoration: 6.6.4 → 6.6.5
kdeplasma-addons: 6.6.4 → 6.6.5, [31;1m27.5 KiB[0m
kglobalacceld: 6.6.4 → 6.6.5
kinfocenter: 6.6.4 → 6.6.5
kmenuedit: 6.6.4 → 6.6.5
knighttime: 6.6.4 → 6.6.5
kpipewire: 6.6.4 → 6.6.5
krdp: 6.6.4 → 6.6.5
kscreen: 6.6.4 → 6.6.5, [31;1m13.8 KiB[0m
kscreenlocker: 6.6.4 → 6.6.5
ksshaskpass: 6.6.4 → 6.6.5
ksystemstats: 6.6.4 → 6.6.5, [31;1m9.7 KiB[0m
ktextaddons: 2.0.1 → 2.0.2, [31;1m106.5 KiB[0m
kwallet-pam: 6.6.4 → 6.6.5
kwayland-integration: 6.6.4 → 6.6.5
kwayland: 6.6.4 → 6.6.5
kwin-x11: 6.6.4 → 6.6.5, [31;1m44.8 KiB[0m
kwin: 6.6.4 → 6.6.5, [31;1m62.3 KiB[0m
kwrited: 6.6.4 → 6.6.5
layer-shell-qt: 6.6.4 → 6.6.5
libkscreen: 6.6.4 → 6.6.5, [31;1m15.8 KiB[0m
libksysguard: 6.6.4 → 6.6.5, [31;1m11.2 KiB[0m
libplasma: 6.6.4 → 6.6.5, [32;1m-12.3 KiB[0m
linux: 6.18.29 → 6.18.30, [31;1m11.7 KiB[0m
milou: 6.6.4 → 6.6.5
mise: 2026.4.20 → 2026.5.6, [31;1m9.2 MiB[0m
moby: 29.4.2 → 29.4.3
nixos-init: [31;1m8.2 KiB[0m
nixos-manual: [31;1m8.2 KiB[0m
nixos-system-kushtaka: 26.05.20260512.48d91f2 → 26.05.20260514.8a1b012
nixos-system-snallygaster: 26.05.20260512.48d91f2 → 26.05.20260514.8a1b012
nixos-system-wendigo: 26.05.20260512.48d91f2 → 26.05.20260514.8a1b012
noto-fonts: 2026.04.01 → 2026.05.01
nvim-treesitter: [31;1m14.8 KiB[0m
ocean-sound-theme: 6.6.4 → 6.6.5
plasma-activities-stats: 6.6.4 → 6.6.5
plasma-activities: 6.6.4 → 6.6.5
plasma-browser-integration: 6.6.4 → 6.6.5
plasma-desktop: 6.6.4 → 6.6.5, [31;1m53.7 KiB[0m
plasma-integration: 6.6.4, 6.6.4-qt5 → 6.6.5, 6.6.5-qt5
plasma-nano: 6.6.4 → 6.6.5
plasma-nm: 6.6.4 → 6.6.5
plasma-pa: 6.6.4 → 6.6.5
plasma-sdk: 6.6.4 → 6.6.5
plasma-systemmonitor: 6.6.4 → 6.6.5
plasma-workspace-wallpapers: 6.6.4 → 6.6.5
plasma-workspace: 6.6.4 → 6.6.5, [31;1m33.9 KiB[0m
plasma5support: 6.6.4 → 6.6.5
polkit-kde-agent: 1-6.6.4 → 1-6.6.5
powerdevil: 6.6.4 → 6.6.5
print-manager: 6.6.4 → 6.6.5, [31;1m13.6 KiB[0m
python3.13-sentry-sdk: 2.59.0 → 2.60.0, [31;1m117.5 KiB[0m
qqc2-breeze-style: 6.6.4 → 6.6.5
rclone: 1.74.0 → 1.74.1, [31;1m16.9 KiB[0m
serena-agent: [31;1m100.9 KiB[0m
source: [32;1m-2.0 MiB[0m
spectacle: 6.6.4 → 6.6.5, [31;1m23.4 KiB[0m
systemsettings: 6.6.4 → 6.6.5
unit-network-setup.service: ε → ∅
unit-network.target: ∅ → ε
unit-networking-scripted.target: ∅ → ε
unit-script-network-local-commands: ∅ → ε
unit-script-network-setup: ε → ∅
vimplugin-ale: 4.0.0-unstable-2026-04-15 → 4.0.0-unstable-2026-05-12, [31;1m16.3 KiB[0m
vimplugin-nvim-autopairs: 0.10.0-unstable-2026-01-30 → 0.10.0-unstable-2026-05-08
vimplugin-nvim-lspconfig: 2.8.0 → 2.9.0, [31;1m229.3 KiB[0m
vimplugin-telescope-fzf-native.nvim: 0-unstable-2025-11-07 → 0-unstable-2026-05-06
x86_energy_perf_policy: 6.18.29 → 6.18.30
xdg-desktop-portal-kde: 6.6.4 → 6.6.5
```

</details>