### PR TITLE
add .local/bin to path

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -34,7 +34,11 @@
       "Read(//home/grue/.claude/plugins/marketplaces/daymade-skills/skill-creator/**)",
       "Bash(python3 -m scripts.init_skill --help)",
       "Skill(nix-config)",
-      "WebSearch"
+      "WebSearch",
+      "mcp__plugin_claude-code-home-manager_serena__check_onboarding_performed",
+      "mcp__plugin_claude-code-home-manager_serena__initial_instructions",
+      "Read(//home/grue/.claude/skills/**)",
+      "Read(//home/grue/.claude/plugins/**)"
     ]
   },
   "outputStyle": "Explanatory",

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ result-*
 
 *.orig
 *.qcow2
+
+docs/summaries/

--- a/flake.lock
+++ b/flake.lock
@@ -433,11 +433,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1779169692,
-        "narHash": "sha256-VX02qq1wmoAwNVReZWfwlS4HGllzPT1cG4HQsCQGk8Y=",
+        "lastModified": 1779198268,
+        "narHash": "sha256-v83Ri37cD4f4cfYuXm9XhUavcp7UJmOiypAafi64/NA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "23c53fddd911c4dea92ba9fb95b6c9df0528fce0",
+        "rev": "25413609751dd974d5c21c74241a9309b892d0ec",
         "type": "github"
       },
       "original": {

--- a/home/modules/claude/default.nix
+++ b/home/modules/claude/default.nix
@@ -10,6 +10,36 @@
     # ── Skills ────────────────────────────────────────────────────────────
     skills = ./skills;
 
+    # ── MCP servers ─────────────────────────────────────────────────────────
+    # Written to .mcp.json (the dedicated MCP config file Claude Code reads).
+    # Note: mcpServers inside `settings` maps to settings.json which Claude Code
+    # does NOT load MCPs from — always use this top-level option instead.
+    #
+    # CONTEXT7_API_KEY is loaded by `load-secrets` in zsh at shell startup
+    # before Claude Code launches, so it is already in the environment when
+    # the MCP child process is spawned.
+    # "$VAR" interpolation in MCP env blocks is the standard Claude Code
+    # pattern; shell command substitution ($(…)) is not supported there.
+    mcpServers = {
+      context7 = {
+        command = "npx";
+        args = ["-y" "@upstash/context7-mcp@latest"];
+        env = {
+          CONTEXT7_API_KEY = "$CONTEXT7_API_KEY";
+        };
+      };
+
+      serena = {
+        command = "serena";
+        args = [
+          "start-mcp-server"
+          "--context"
+          "claude-code"
+          "--project-from-cwd"
+        ];
+      };
+    };
+
     settings = {
       # ── Plugins ──────────────────────────────────────────────────────────
       enabledPlugins = import ./plugins.nix;
@@ -34,20 +64,50 @@
       # ── Status line ───────────────────────────────────────────────────────
       statusLine = import ./statusline.nix pkgs;
 
-      # ── MCP servers ───────────────────────────────────────────────────────
-      # CONTEXT7_API_KEY is loaded by `load-secrets` in zsh at shell startup
-      # before Claude Code launches, so it is already in the environment when
-      # the MCP child process is spawned.
-      # "$VAR" interpolation in MCP env blocks is the standard Claude Code
-      # pattern; shell command substitution ($(…)) is not supported there.
-      mcpServers = {
-        context7 = {
-          command = "npx";
-          args = ["-y" "@upstash/context7-mcp@latest"];
-          env = {
-            CONTEXT7_API_KEY = "$CONTEXT7_API_KEY";
-          };
-        };
+      # ── Hooks ─────────────────────────────────────────────────────────────
+      hooks = {
+        SessionStart = [
+          {
+            matcher = "";
+            hooks = [
+              {
+                type = "command";
+                command = "serena-hooks activate --client=claude-code";
+              }
+            ];
+          }
+        ];
+        PreToolUse = [
+          {
+            matcher = "";
+            hooks = [
+              {
+                type = "command";
+                command = "serena-hooks remind --client=claude-code";
+              }
+            ];
+          }
+          {
+            matcher = "mcp__serena__*";
+            hooks = [
+              {
+                type = "command";
+                command = "serena-hooks auto-approve --client=claude-code";
+              }
+            ];
+          }
+        ];
+        Stop = [
+          {
+            matcher = "";
+            hooks = [
+              {
+                type = "command";
+                command = "serena-hooks cleanup --client=claude-code";
+              }
+            ];
+          }
+        ];
       };
     };
   };

--- a/home/modules/claude/plugins.nix
+++ b/home/modules/claude/plugins.nix
@@ -30,9 +30,6 @@
   "mermaid-tools@daymade-skills" = true;
   "statusline-generator@daymade-skills" = true;
 
-  # ── Context / data ─────────────────────────────────────────────────────
-  "context7@claude-plugins-official" = true;
-
   # ── Output style ───────────────────────────────────────────────────────
   "explanatory-output-style@claude-plugins-official" = true;
 }

--- a/home/modules/zsh/default.nix
+++ b/home/modules/zsh/default.nix
@@ -21,6 +21,15 @@
       if [[ -o login ]] && [[ -n "$NIXOS_REBOOT_PENDING" ]]; then
         echo "⚠ NixOS update staged — reboot to apply."
       fi
+
+      # Launch Claude Code with Serena's system-prompt override enabled.
+      # Use `serclaude` to bias the agent toward Serena's MCP tools;
+      # plain `claude` keeps the default Claude Code system prompt.
+      serclaude() {
+        local prompt
+        prompt="$(serena prompts print-cc-system-prompt-override)" || return
+        command claude --append-system-prompt="$prompt" "$@"
+      }
     '';
 
     defaultKeymap = "viins";

--- a/nixos/profiles/base.nix
+++ b/nixos/profiles/base.nix
@@ -22,6 +22,8 @@
     backupFileExtension = "hm-bak"; # rename conflicts instead of failing
   };
 
+  environment.localBinInPath = true;
+
   # Set your time zone.
   time.timeZone = "America/New_York";
 


### PR DESCRIPTION
This pull request introduces several improvements to the Claude Code configuration, focusing on better integration with the Serena MCP tooling, enhanced automation via hooks, and improved developer experience. The main changes include restructuring MCP server configuration, adding Serena-related commands and hooks, and simplifying plugin management.

**Serena MCP integration and automation:**

* Added Serena MCP server configuration to the top-level `mcpServers` attribute in `home/modules/claude/default.nix`, ensuring proper server startup and environment variable handling.
* Introduced session and tool-use hooks in `home/modules/claude/default.nix` to automate Serena-related workflows (activate, remind, auto-approve, and cleanup) during various lifecycle events in Claude Code.
* Added a `serclaude` shell function in `home/modules/zsh/default.nix` to launch Claude Code with Serena's system prompt override, making it easier to bias the agent toward Serena MCP tools.

**Permissions and plugin management:**

* Expanded allowed operations in `.claude/settings.local.json` to include Serena MCP functions and additional read permissions for skills and plugins directories.
* Removed the `context7` plugin from the enabled plugins list in `home/modules/claude/plugins.nix`, reflecting the new MCP server configuration approach.

**General environment improvements:**

* Ensured that locally installed binaries are always in the `PATH` by enabling `environment.localBinInPath` in `nixos/profiles/base.nix`.