### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,11 +54,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1779135958,
-        "narHash": "sha256-Wv4zLk2M7K97x+rJYAEOfzdRbGtOM2W1lrRwwsTA52k=",
+        "lastModified": 1779479455,
+        "narHash": "sha256-krR35NSwlfIGtx4EpTWdh2BzfgILbAdTdCJY2GPc3NI=",
         "owner": "charmbracelet",
         "repo": "nur",
-        "rev": "9a29a4ddc19cc0052b0b1624a0ab1d9e0a73dd24",
+        "rev": "3dc9fb4b66b7354865ee9a40609797997284541f",
         "type": "github"
       },
       "original": {
@@ -255,11 +255,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779157263,
-        "narHash": "sha256-VbiyZkRf8/qr7ObmlyfOHJsNAW5tyZ4MB1+cUwAwdrw=",
+        "lastModified": 1779678629,
+        "narHash": "sha256-gHcIFg0mm+KFsg7iZQt67kni3+qR5U3PhEC9P7vKlZ4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "866412a19866b4a8e32d2306a118040afa2b840c",
+        "rev": "612bbe3b405ad5f71d7bf9edecc04b678a061652",
         "type": "github"
       },
       "original": {
@@ -294,11 +294,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778999127,
-        "narHash": "sha256-V5GquqJvAqwFTcpN6hxKSQAtwuJFRUEHmyNKbeaTQDg=",
+        "lastModified": 1779604987,
+        "narHash": "sha256-ZQ5z+fVhxYKtIFwtqGp5O0PD84BM1riASvqDaN5Xs+s=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "f680e0d3c1dbefe298c423691662e238496890f2",
+        "rev": "8fba98c80b48fa013820e0163c5096922fea4ddd",
         "type": "github"
       },
       "original": {
@@ -333,11 +333,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1779099457,
-        "narHash": "sha256-u73aVD/lUmmT3JV+kPDztl7zPwQKd0eobD1AbJltaGs=",
+        "lastModified": 1779258371,
+        "narHash": "sha256-j1iZsLy6oFApqR1oiDmHhvkwxXqcNi0aoSJj643LuwU=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "8792fab9d4a6454a9201675f01326f827ce35ead",
+        "rev": "c97bc4d15bd3473dd095e8e8ba57330ab1943a77",
         "type": "github"
       },
       "original": {
@@ -397,11 +397,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "lastModified": 1779536132,
+        "narHash": "sha256-q+fF42iv/geEbHfgSzy3tS0FF/EyD6XTZ98E6yxiBO8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "rev": "3d8f0f3f72a6cd4d93d0ad13203f2ea1cb7e1456",
         "type": "github"
       },
       "original": {
@@ -413,11 +413,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "lastModified": 1779508470,
+        "narHash": "sha256-Ap9KJX+5xHIn3bPIpfNgT6MEXdAECECwo4/rmlQD74M=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "rev": "29916453413845e54a65b8a1cf996842300cd299",
         "type": "github"
       },
       "original": {
@@ -433,11 +433,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1779198268,
-        "narHash": "sha256-v83Ri37cD4f4cfYuXm9XhUavcp7UJmOiypAafi64/NA=",
+        "lastModified": 1779700276,
+        "narHash": "sha256-XHDqXNn+138xIT4aS2uRgFy5ryU2JFLYSgt6G3W7oCo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "25413609751dd974d5c21c74241a9309b892d0ec",
+        "rev": "77136ffdc281fdd7d4517a14101fc6acd7ae9152",
         "type": "github"
       },
       "original": {
@@ -572,11 +572,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1779135302,
-        "narHash": "sha256-xFg3Dbg9B2AH89tW9SuIM9mRyGuQTbK7cFpTqDouHTs=",
+        "lastModified": 1779370069,
+        "narHash": "sha256-Icg5KELZYwyPuMUONabdaLdEtItTeN9GSUTgwJ4Kt2s=",
         "owner": "oraios",
         "repo": "serena",
-        "rev": "0909ae05f778457086e0529162695cb4f285f79a",
+        "rev": "981f560fa334ba52e9a2a45c702f23d971c9dcca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated update of `flake.lock` inputs.

All hosts built successfully against this lock file.
Merging will trigger `autodeploy.yaml`, which publishes store paths for pickup by `nixos-autodeploy`.

## Package changes

**Added: 1 | Removed: 0
0 | Changed: **

<details>
<summary>Full diff</summary>

```
1password: 8.12.12 → 8.12.21, [31;1m3.6 MiB[0m
adwaita-icon-theme: 49.0 → 50.0, [31;1m25.8 KiB[0m
age: [31;1m12.0 KiB[0m
akonadi-search: [31;1m26.2 KiB[0m
alejandra: [31;1m44.9 KiB[0m
at-spi2-core: 2.58.3 → 2.60.1, [31;1m53.9 KiB[0m
atuin: [31;1m102.3 KiB[0m
aws-c-event-stream: 0.5.7 → 0.7.0
bat: [31;1m22.1 KiB[0m
bootspec: [31;1m64.3 KiB[0m
boringssl: 0.20260413.0 → 0.20260508.0, [31;1m17.3 KiB[0m
bubblewrap: 0.11.1 → 0.11.2
claude-code: 2.1.141 → 2.1.148, [31;1m4.3 MiB[0m
comma-with-db: 2.3.3 → 2.4.1
comma: 2.3.3 → 2.4.1, [31;1m254.5 KiB[0m
coreutils-full: 9.10 → 9.11, [31;1m358.1 KiB[0m
coreutils: 9.10 → 9.11, [31;1m186.2 KiB[0m
crush: 0.70.0 → 0.71.0, [31;1m83.0 KiB[0m
cups: 2.4.16 → 2.4.19
curl: 8.19.0 → 8.20.0, [31;1m20.2 KiB[0m
dash: 0.5.13.2 → 0.5.13.3
delta: [31;1m34.7 KiB[0m
delve: 1.26.1 → 1.26.3, [32;1m-1.1 MiB[0m
discord: 1.0.137 → 1.0.138, [31;1m569.1 KiB[0m
docker-buildx: [31;1m72.0 KiB[0m
docker-compose: 5.1.3 → 5.1.4, [31;1m96.2 KiB[0m
docker-containerd: 29.4.3 → 29.5.1, [31;1m88.0 KiB[0m
docker-runc: 29.4.3 → 29.5.1, [31;1m8.1 KiB[0m
docker-tini: 29.4.3 → 29.5.1
docker: 29.4.3 → 29.5.1, [31;1m48.8 KiB[0m
doggo: 1.1.5 → 1.1.6, [31;1m60.1 KiB[0m
electron-unwrapped: 39.8.9, 41.3.0 → 40.10.0, 41.6.1, [31;1m5.3 MiB[0m
electron: 39.8.9, 41.3.0 → 40.10.0, 41.6.1
envfs: [31;1m36.9 KiB[0m
etc-environment.d: ∅ → 50-systemd-path.conf
ethtool: 6.19 → 7.0, [31;1m18.1 KiB[0m
ethtool: 6.19 → 7.0, [31;1m9.1 KiB[0m
expat: 2.7.5 → 2.8.0, [31;1m12.0 KiB[0m
eza: [31;1m16.9 KiB[0m
fd: [31;1m24.9 KiB[0m
ffmpeg-headless: 8.0.1 → 8.1, [31;1m605.1 KiB[0m
ffmpeg-headless: 8.0.1 → 8.1, [31;1m866.8 KiB[0m
ffmpeg: 8.0.1 → 8.1, [31;1m601.1 KiB[0m
file: 5.45 → 5.47, [31;1m4.1 MiB[0m
firefox-unwrapped: 150.0.3 → 151.0.1, [31;1m1.8 MiB[0m
firefox: 150.0.3 → 151.0.1, [31;1m44.4 KiB[0m
firmware: [31;1m34.6 KiB[0m
font-util: 1.4.1 → 1.4.2
gdb-host-cpu-only: [31;1m160.5 KiB[0m
gdk-pixbuf: 2.44.5 → 2.44.6
gh-dash: 4.24.0 → 4.24.1, [31;1m140.0 KiB[0m
gh: [31;1m40.0 KiB[0m
ghostscript-with-X: 10.06.0 → 10.07.0, [31;1m74.3 KiB[0m
git-minimal: 2.53.0 → 2.54.0, [31;1m728.1 KiB[0m
git-with-svn: 2.53.0 → 2.54.0, [31;1m934.6 KiB[0m
git: 2.53.0 → 2.54.0, [31;1m933.4 KiB[0m
glib: 2.86.3 → 2.88.1, [31;1m600.0 KiB[0m
glibmm: 2.86.0 → 2.88.0
gnome-settings-daemon: 49.1-gsettings → 50.1-gsettings
gnupg: [32;1m-1.2 MiB[0m
gnupg: [32;1m-2.6 MiB[0m
gnutar: [32;1m-2.8 MiB[0m
gnutls: 3.8.12 → 3.8.13, [31;1m423.6 KiB[0m
go-tools: [31;1m52.1 KiB[0m
go: 1.26.2 → 1.26.3, [31;1m163.5 KiB[0m
godef: [31;1m8.0 KiB[0m
gogetdoc-unstable: [31;1m8.0 KiB[0m
golangci-lint: [31;1m64.0 KiB[0m
gopls: 0.21.1 → 0.22.0, [32;1m-7.6 MiB[0m
gotools: [31;1m212.8 KiB[0m
gsettings-desktop-schemas: 49.1 → 50.1, [31;1m800.8 KiB[0m
gstreamer: [31;1m34.5 KiB[0m
gstreamer: [31;1m63.5 KiB[0m
gtk4: 4.20.3 → 4.22.4, [31;1m1.1 MiB[0m
gtkmm: 4.20.0 → 4.22.0, [31;1m97.6 KiB[0m
harfbuzz: 12.3.0 → 13.2.1, [31;1m160.8 KiB[0m
idna: 3.11 → 3.15, [32;1m-23.8 KiB[0m
ijs: 10.06.0 → 10.07.0
imagemagick: 7.1.2-19 → 7.1.2-23
index-x86_64-linux: [31;1m15.2 KiB[0m
index-x86_64: [31;1m403.7 KiB[0m
initrd-linux: 6.18.31 → 6.18.32, [31;1m181.8 KiB[0m
initrd-linux: 6.18.31 → 6.18.32, [31;1m223.9 KiB[0m
initrd-linux: 6.18.31 → 6.18.32, [31;1m226.6 KiB[0m
iproute2: 6.19.0 → 7.0.0, [31;1m22.9 KiB[0m
jemalloc: 5.3.0-unstable-2025-09-12 → 5.3.1, [32;1m-5.2 MiB[0m
jjui: 0.10.5 → 0.10.6, [31;1m35.6 KiB[0m
jujutsu: [31;1m26.9 KiB[0m
just: [31;1m17.2 KiB[0m
kirigami-addons: 1.12.0 → 1.12.1, [31;1m66.8 KiB[0m
kitty: 0.46.2 → 0.47.0, [31;1m2.3 MiB[0m
libadwaita: 1.8.5.1 → 1.9.0, [32;1m-169.5 KiB[0m
libarchive: 3.8.6 → 3.8.7
libassuan: [32;1m-103.4 KiB[0m
libbpf: 1.6.3 → 1.7.0, [31;1m152.7 KiB[0m
libbpf: 1.6.3 → 1.7.0, [31;1m72.8 KiB[0m
libcap-ng: 0.9.2 → 0.9.3, [31;1m13.7 KiB[0m
libdovi: [31;1m663.9 KiB[0m
libdrm: 2.4.131 → 2.4.133
libdrm: 2.4.131 → 2.4.133, [31;1m14.0 KiB[0m
libetebase: [31;1m9.9 KiB[0m
libexif: 0.6.25 → 0.6.26, [31;1m254.0 KiB[0m
libfido2: 1.16.0 → 1.17.0, [31;1m47.9 KiB[0m
libfido2: 1.16.0 → 1.17.0, [31;1m88.8 KiB[0m
libidn2: [32;1m-17.5 KiB[0m
libpng: 1.6.56 → ∅, [32;1m-255.8 KiB[0m
libpq: 18.2 → 18.4
libraqm: 0.10.4 → 0.10.5
libraw: 0.22.0 → 0.22.1, [31;1m8.1 KiB[0m
librsvg: 2.61.4 → 2.62.1, [31;1m212.7 KiB[0m
libsodium: 1.0.21-unstable-2026-03-29 → 1.0.22-unstable-2026-04-09, [31;1m42.6 KiB[0m
libxml2: 2.15.1 → 2.15.2, [31;1m8.3 KiB[0m
libxpm: 3.5.18 → 3.5.19
linux-firmware: 20260410 → 20260519, [31;1m2.4 MiB[0m
linux: 6.18.31 → 6.18.32, [31;1m10.9 MiB[0m
llhttp: 9.3.1 → 9.4.1
lnav: [31;1m227.5 KiB[0m
luajit: 2.1.1741730670 → 2.1.1774638290, [31;1m12.8 KiB[0m
lvm2: 2.03.38 → 2.03.39, [32;1m-210.6 KiB[0m
lvm2: 2.03.38 → 2.03.39, [32;1m-236.1 KiB[0m
make-initrd-ng: [31;1m35.8 KiB[0m
mbedtls: 3.6.5 → 3.6.6, [31;1m228.9 KiB[0m
mbedtls: 3.6.5 → 3.6.6, [31;1m479.9 KiB[0m
mesa: 26.1.0 → 26.1.1, [31;1m140.4 KiB[0m
mesa: 26.1.0 → 26.1.1, [31;1m72.2 KiB[0m
mise: 2026.5.6 → 2026.5.12, [31;1m2.3 MiB[0m
moby: 29.4.3 → 29.5.1, [31;1m943.2 KiB[0m
nghttp2: 1.68.1 → 1.69.0, [32;1m-115.5 KiB[0m
ngtcp2: 1.22.0 → 1.22.1
nh-unwrapped: [31;1m10.8 KiB[0m
nix-direnv: 3.1.1 → 3.1.2
nix-index: [31;1m205.4 KiB[0m
nix-output-monitor: [31;1m20.0 KiB[0m
nixos-autodeploy: [31;1m53.8 KiB[0m
nixos-system-kushtaka: 26.05.20260515.d233902 → 26.05.20260523.3d8f0f3
nixos-system-snallygaster: 26.05.20260515.d233902 → 26.05.20260523.3d8f0f3
nixos-system-wendigo: 26.05.20260515.d233902 → 26.05.20260523.3d8f0f3
node_exporter: [31;1m24.0 KiB[0m
nodejs-slim: 24.14.1 → 24.15.0, [31;1m2.3 MiB[0m
nodejs: 24.14.1 → 24.15.0, [32;1m-11.4 KiB[0m
noto-fonts-color-emoji-png: 2.051 → ∅, [32;1m-10.9 MiB[0m
npth: [32;1m-54.2 KiB[0m
nsncd: [31;1m34.8 KiB[0m
nspr: 4.38.2 → 4.39
nss-cacert: 3.121, 3.121-p11kit → 3.123, 3.123-p11kit, [32;1m-124.2 KiB[0m
nss: 3.112.3, 3.123.1 → 3.112.5, 3.124
nvim-host-python3: 3.13.12 → 3.13.13
openexr: 3.3.8 → 3.4.10, [31;1m96.0 KiB[0m
openjdk-minimal-jre: 21.0.10+7 → 21.0.12+2, [31;1m277.8 KiB[0m
openjdk: 17.0.18+8, 21.0.10+7, 25.0.2+10, 8u472-b08 → 17.0.20+2, 21.0.12+2, 25.0.4+1, 8u502-b01, [31;1m4.8 MiB[0m
openssl: 3.6.1 → 3.6.2, [31;1m12.9 KiB[0m
orca: 49.5 → 50.1.2, [31;1m1.5 MiB[0m
oxygen-icons: 6.1.0 → 6.2.0, [31;1m2.7 MiB[0m
pango: 1.57.0 → 1.57.1, [31;1m22.8 KiB[0m
pciutils: 3.14.0 → 3.15.0, [31;1m24.9 KiB[0m
pciutils: 3.14.0 → 3.15.0, [31;1m25.0 KiB[0m
perl5.42.0-Mozilla-CA: [32;1m-56.0 KiB[0m
pipewire: 1.6.3 → 1.6.5, [31;1m23.2 KiB[0m
pipewire: 1.6.3 → 1.6.5, [31;1m45.4 KiB[0m
plutosvg: 0.0.7 → 0.0.8
plutovg: 1.3.2 → 1.3.3
presenterm: [31;1m21.3 KiB[0m
protonmail-bridge: [31;1m28.3 KiB[0m
pyright-internal: [32;1m-1010.5 KiB[0m
python3.13-certifi: [32;1m-56.0 KiB[0m
python3.13-packaging: 25.0 → 26.1, [31;1m400.1 KiB[0m
python3.13-pygobject: 3.54.5 → 3.56.2, [32;1m-13.7 KiB[0m
python3: 3.13.12 → 3.13.13, [31;1m134.6 KiB[0m
python3: 3.13.12 → 3.13.13, [31;1m199.9 KiB[0m
qtdeclarative: [32;1m-116.8 KiB[0m
rclone: [31;1m60.1 KiB[0m
reftools: [31;1m20.0 KiB[0m
revive: [31;1m8.0 KiB[0m
ripgrep: [32;1m-137.2 KiB[0m
rootlesskit: [31;1m28.8 KiB[0m
ruby: [31;1m55.2 KiB[0m
ruff: [31;1m99.9 KiB[0m
sd-switch: [31;1m28.4 KiB[0m
sd: [31;1m55.2 KiB[0m
sdl2-compat: 2.32.66 → 2.32.68
sdl3: 3.4.2 → 3.4.8, [31;1m25.1 KiB[0m
signal-desktop: 8.8.0 → 8.9.1, [32;1m-4.9 MiB[0m
simdutf: 8.1.0 → 9.0.0, [31;1m659.3 KiB[0m
source: [31;1m2.2 MiB[0m
starship: [31;1m32.4 KiB[0m
steam-run: [32;1m-29.8 KiB[0m
steam: [32;1m-33.7 KiB[0m
stylua: 2.4.1 → 2.5.2, [31;1m140.2 KiB[0m
subversion-client: [31;1m44.6 KiB[0m
switch-to-configuration: [31;1m22.0 KiB[0m
systemd: [31;1m36.6 KiB[0m
systemd: [31;1m81.7 KiB[0m
tailscale: 1.98.0 → 1.98.2, [31;1m40.1 KiB[0m
thin-provisioning-tools: [31;1m21.7 KiB[0m
tinysparql: 3.10.1 → 3.11.1, [31;1m37.9 KiB[0m
tree-sitter: [31;1m11.2 KiB[0m
trippy: [31;1m75.3 KiB[0m
tzdata: 2026a → 2026b
unbound: 1.24.2 → 1.25.0, [31;1m25.6 KiB[0m
unit-blueman-applet.service: ε → ∅
usage: [31;1m39.3 KiB[0m
util-linux-minimal: [32;1m-279.8 KiB[0m
util-linux: [32;1m-151.3 KiB[0m
viddy: [31;1m67.8 KiB[0m
vim-full: 9.2.0340 → 9.2.0389
vimplugin-ale: 4.0.0-unstable-2026-05-12 → 4.0.0-unstable-2026-05-17, [31;1m16.4 KiB[0m
vimplugin-conform.nvim: 9.1.0-unstable-2026-04-23 → 9.1.0-unstable-2026-05-15
vimplugin-nvim-tree.lua: 1.17.0-unstable-2026-04-30 → 1.17.0-unstable-2026-05-15
wayland: 1.24.0 → 1.25.0, [31;1m9.1 KiB[0m
wishlist: [31;1m12.0 KiB[0m
x86_energy_perf_policy: 6.18.31 → 6.18.32
xdg-dbus-proxy: 0.1.6 → 0.1.7
xdg-user-dirs: 0.19 → 0.20, [31;1m30.7 KiB[0m
xh: [31;1m142.7 KiB[0m
xrandr: 1.5.3 → 1.5.4
xterm: 407 → 410
zoxide: [31;1m26.7 KiB[0m
```

</details>