### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,11 +54,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1779479455,
-        "narHash": "sha256-krR35NSwlfIGtx4EpTWdh2BzfgILbAdTdCJY2GPc3NI=",
+        "lastModified": 1779889808,
+        "narHash": "sha256-m9JkIZFl0KLKPFZyx4T9Nat6TBUhUSbxSu8FVCwPHBw=",
         "owner": "charmbracelet",
         "repo": "nur",
-        "rev": "3dc9fb4b66b7354865ee9a40609797997284541f",
+        "rev": "479c2475be0f92c907083f8edeaa83704d5493e9",
         "type": "github"
       },
       "original": {
@@ -255,11 +255,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779678629,
-        "narHash": "sha256-gHcIFg0mm+KFsg7iZQt67kni3+qR5U3PhEC9P7vKlZ4=",
+        "lastModified": 1779726696,
+        "narHash": "sha256-/p37CB5n6Wpw250b0Lq0CYwNq2D8uGKzDoBulyLcQqA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "612bbe3b405ad5f71d7bf9edecc04b678a061652",
+        "rev": "1a95e2efb477959b70b4a14c51035975c0481df6",
         "type": "github"
       },
       "original": {
@@ -333,11 +333,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1779258371,
-        "narHash": "sha256-j1iZsLy6oFApqR1oiDmHhvkwxXqcNi0aoSJj643LuwU=",
+        "lastModified": 1779826373,
+        "narHash": "sha256-3sRzgLX86qV5NlhWUAufLmHwkyP03tmL3VdZIM13dEo=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "c97bc4d15bd3473dd095e8e8ba57330ab1943a77",
+        "rev": "ef4efb84766a166c906bd55759574676bf91267c",
         "type": "github"
       },
       "original": {
@@ -397,11 +397,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1779536132,
-        "narHash": "sha256-q+fF42iv/geEbHfgSzy3tS0FF/EyD6XTZ98E6yxiBO8=",
+        "lastModified": 1779877693,
+        "narHash": "sha256-NOF9NAREhxr50bbBfVcVOq+ArCMSoe8dP79Pk2uyARk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3d8f0f3f72a6cd4d93d0ad13203f2ea1cb7e1456",
+        "rev": "4100e830e085863741bc69b156ec4ccd53ab5be0",
         "type": "github"
       },
       "original": {
@@ -413,11 +413,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1779508470,
-        "narHash": "sha256-Ap9KJX+5xHIn3bPIpfNgT6MEXdAECECwo4/rmlQD74M=",
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "29916453413845e54a65b8a1cf996842300cd299",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
         "type": "github"
       },
       "original": {
@@ -433,11 +433,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1779700276,
-        "narHash": "sha256-XHDqXNn+138xIT4aS2uRgFy5ryU2JFLYSgt6G3W7oCo=",
+        "lastModified": 1779959617,
+        "narHash": "sha256-SdkrLpT0OjinxiUUsRxMajaT4OzOXUsPsPudVnSV9SA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "77136ffdc281fdd7d4517a14101fc6acd7ae9152",
+        "rev": "afe768efc8997648b44a9574d8cd7ab1054fff50",
         "type": "github"
       },
       "original": {
@@ -572,11 +572,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1779370069,
-        "narHash": "sha256-Icg5KELZYwyPuMUONabdaLdEtItTeN9GSUTgwJ4Kt2s=",
+        "lastModified": 1779881517,
+        "narHash": "sha256-mgC2rUVlBRHP+OFMW8BiWNXq13eqWMjoLBt2jP9dJXU=",
         "owner": "oraios",
         "repo": "serena",
-        "rev": "981f560fa334ba52e9a2a45c702f23d971c9dcca",
+        "rev": "7bf30080f6aa8fc1f983e1d72bc91dd790f28d29",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated update of `flake.lock` inputs.

All hosts built successfully against this lock file.
Merging will trigger `autodeploy.yaml`, which publishes store paths for pickup by `nixos-autodeploy`.

## Package changes

**Added: 0
0 | Removed: 0
0 | Changed: **

<details>
<summary>Full diff</summary>

```
atuin: 18.15.2 → 18.16.1, [31;1m832.6 KiB[0m
bind: 9.20.22 → 9.20.23
claude-code: 2.1.148 → 2.1.152, [31;1m2.5 MiB[0m
cmark: 0.31.1 → 0.31.2
crush: 0.71.0 → 0.73.0, [31;1m82.6 KiB[0m
ddcutil: 2.2.6 → 2.2.7, [31;1m70.0 KiB[0m
firefox-unwrapped: 151.0.1 → 151.0.2, [31;1m1.8 MiB[0m
firefox: 151.0.1 → 151.0.2
fortls: 3.2.2 → ∅, [32;1m-1.6 MiB[0m
fzf: 0.72.0 → 0.73.1, [31;1m71.9 KiB[0m
initrd-linux: 6.18.32 → 6.18.33, [32;1m-100.0 KiB[0m
initrd-linux: 6.18.32 → 6.18.33, [32;1m-102.6 KiB[0m
initrd-linux: 6.18.32 → 6.18.33, [32;1m-104.9 KiB[0m
json5: 0.13.0 → ∅, [32;1m-280.8 KiB[0m
libqalculate: 5.10.0 → 5.11.0, [31;1m129.2 KiB[0m
linux: 6.18.32 → 6.18.33, [31;1m25.9 KiB[0m
nixos-manual: [31;1m26.0 KiB[0m
nixos-rebuild-ng: 26.05 → 26.11
nixos-system-kushtaka: 26.05.20260523.3d8f0f3 → 26.11.20260527.4100e83
nixos-system-snallygaster: 26.05.20260523.3d8f0f3 → 26.11.20260527.4100e83
nixos-system-wendigo: 26.05.20260523.3d8f0f3 → 26.11.20260527.4100e83
nodeenv: 1.10.0 → ∅, [32;1m-143.5 KiB[0m
onnxruntime: 1.24.4 → 1.26.0, [31;1m3.1 MiB[0m
packaging: 26.0 → ∅, [32;1m-582.0 KiB[0m
picotts: ∅ → 0-unstable-2021-05-06, [31;1m6.8 MiB[0m
pyright-internal: 1.1.409 → 1.1.410, [31;1m59.4 MiB[0m
pyright: 1.1.403, 1.1.409 → 1.1.410, [32;1m-17.7 MiB[0m
rclone: 1.74.1 → 1.74.2
ruff: 0.15.13 → 0.15.14, [31;1m42.5 KiB[0m
serena-agent: 1.5.2.dev0 → 1.5.4.dev0, [31;1m11.1 KiB[0m
source: [31;1m523.0 KiB[0m
svox: 0-unstable-2021-05-06 → ∅, [32;1m-6.8 MiB[0m
vimplugin-conform.nvim: 9.1.0-unstable-2026-05-15 → 9.1.0-unstable-2026-05-24
vimplugin-fzf.vim: 0-unstable-2026-04-10 → 0-unstable-2026-05-24
vimplugin-fzf: 0.72.0 → 0.73.1, [31;1m67.6 KiB[0m
x86_energy_perf_policy: 6.18.32 → 6.18.33
```

</details>