### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,11 +54,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1780060830,
-        "narHash": "sha256-rr3DV8WauvR+KeEfBa/bOlGsOX5VqppACZnmb0V202Q=",
+        "lastModified": 1780087526,
+        "narHash": "sha256-MIW62CNple/GJkrUheM5WdqrEOfdYaiS/EUUnxK63F0=",
         "owner": "charmbracelet",
         "repo": "nur",
-        "rev": "9144930424a16d5edc7d25ae2a29ce4125f634a7",
+        "rev": "3a33c13df4a7b076ba77b13e3219cb1cf38e341a",
         "type": "github"
       },
       "original": {
@@ -255,11 +255,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779969295,
-        "narHash": "sha256-HwIJ3tOcwSMiV75L7KqJXciXR9UfT+d7rwOZMX7cTnA=",
+        "lastModified": 1780099287,
+        "narHash": "sha256-efIPwVGtIWIjWcznhaop6XN6HxnOL8800hF6CBNvlqQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "61e2c9659324181e0f0ed911958c536333b1d4f6",
+        "rev": "7d8127d308c3fb9664f7e643eec944be74ebb37d",
         "type": "github"
       },
       "original": {
@@ -294,11 +294,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779604987,
-        "narHash": "sha256-ZQ5z+fVhxYKtIFwtqGp5O0PD84BM1riASvqDaN5Xs+s=",
+        "lastModified": 1780210899,
+        "narHash": "sha256-4axz3OBPTKa6LIkXV8n0lc63MQU+et2CB5DGobEAi6k=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "8fba98c80b48fa013820e0163c5096922fea4ddd",
+        "rev": "97df9dc0b7c924344b793a15c1e8e4522ebb854e",
         "type": "github"
       },
       "original": {
@@ -332,12 +332,15 @@
       }
     },
     "nixos-hardware": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_3"
+      },
       "locked": {
-        "lastModified": 1779826373,
-        "narHash": "sha256-3sRzgLX86qV5NlhWUAufLmHwkyP03tmL3VdZIM13dEo=",
+        "lastModified": 1780065812,
+        "narHash": "sha256-SCSLUKBmwlSLGQ8Xbr8PjRFtiHNk0l9ktqkcmqdBkfE=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "ef4efb84766a166c906bd55759574676bf91267c",
+        "rev": "b76b5639c0593e0aeb0b5879ad62d4b30596c144",
         "type": "github"
       },
       "original": {
@@ -397,11 +400,24 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1779877693,
-        "narHash": "sha256-NOF9NAREhxr50bbBfVcVOq+ArCMSoe8dP79Pk2uyARk=",
+        "lastModified": 1767892417,
+        "narHash": "sha256-8bW3q88CEg2u4hSP66Vf4lpbLonHz7hqDNBMcCY7E9U=",
+        "rev": "3497aa5c9457a9d88d71fa93a4a8368816fbeeba",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.05pre924538.3497aa5c9457/nixexprs.tar.xz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1780030872,
+        "narHash": "sha256-u6WU/yd/o8iYQrHX3RAwO1hYa3LkoSL+WNQD0rJfJZQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4100e830e085863741bc69b156ec4ccd53ab5be0",
+        "rev": "e9a7635a57597d9754eccebdfc7045e6c8600e6b",
         "type": "github"
       },
       "original": {
@@ -411,7 +427,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_5": {
       "locked": {
         "lastModified": 1779560665,
         "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
@@ -430,14 +446,14 @@
     "nur": {
       "inputs": {
         "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs_4"
+        "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1780062944,
-        "narHash": "sha256-gIpZdpqV6+NcKP63bV4zrgXHb0BKVZwU8rFHGc0LZyU=",
+        "lastModified": 1780216933,
+        "narHash": "sha256-6M3uf+ZNzq6ZPmgSsUpqpYAFBRxm5I2/eUZOwl1hLIY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c95d394d24fb1a3583266576b46c555181d5b312",
+        "rev": "d3a8dfb293733206b15bd0ea6c3597c32fae8913",
         "type": "github"
       },
       "original": {
@@ -505,7 +521,7 @@
         "nix-index-database": "nix-index-database",
         "nixos-autodeploy": "nixos-autodeploy",
         "nixos-hardware": "nixos-hardware",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_4",
         "nur": "nur",
         "serena": "serena"
       }


### PR DESCRIPTION
Automated update of `flake.lock` inputs.

All hosts built successfully against this lock file.
Merging will trigger `autodeploy.yaml`, which publishes store paths for pickup by `nixos-autodeploy`.

## Package changes

**Added: 0
0 | Removed: 0
0 | Changed: **

<details>
<summary>Full diff</summary>

```
claude-code: 2.1.152 → 2.1.154, [31;1m752.0 KiB[0m
crush: 0.74.0 → 0.74.1, [31;1m36.2 KiB[0m
docker-containerd: 29.5.1 → 29.5.2
docker-runc: 29.5.1 → 29.5.2
docker-tini: 29.5.1 → 29.5.2
docker: 29.5.1 → 29.5.2
electron-unwrapped: 40.10.0, 41.6.1 → 40.10.2, 41.7.1, [31;1m12.0 KiB[0m
electron: 40.10.0, 41.6.1 → 40.10.2, 41.7.1
gh: 2.92.0 → 2.93.0, [31;1m52.1 KiB[0m
glfw-minecraft: [32;1m-267.4 KiB[0m
glfw: [32;1m-534.7 KiB[0m
index-x86_64-linux: [31;1m8.2 KiB[0m
index-x86_64: [31;1m1.2 MiB[0m
libglvnd: [32;1m-4.3 MiB[0m
moby: 29.5.1 → 29.5.2
nixos-system-kushtaka: 26.11.20260527.4100e83 → 26.11.20260529.e9a7635
nixos-system-snallygaster: 26.11.20260527.4100e83 → 26.11.20260529.e9a7635
nixos-system-wendigo: 26.11.20260527.4100e83 → 26.11.20260529.e9a7635
samba: 4.23.5 → 4.23.8, [31;1m57.2 KiB[0m
slirp4netns: 1.3.3 → 1.3.4
source: [31;1m42.3 KiB[0m
tailscale: 1.98.2 → 1.98.3
vimplugin-ale: 4.0.0-unstable-2026-05-17 → 4.0.0-unstable-2026-05-28
```

</details>