### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,11 +54,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1780087526,
-        "narHash": "sha256-MIW62CNple/GJkrUheM5WdqrEOfdYaiS/EUUnxK63F0=",
+        "lastModified": 1780436821,
+        "narHash": "sha256-iXo+zR2pUChuMwvqtG9GRiabLAsUC4xtdw+R7tFxSMA=",
         "owner": "charmbracelet",
         "repo": "nur",
-        "rev": "3a33c13df4a7b076ba77b13e3219cb1cf38e341a",
+        "rev": "6395f6f83d297eff07986ab320aa514f39d2b096",
         "type": "github"
       },
       "original": {
@@ -255,11 +255,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780099287,
-        "narHash": "sha256-efIPwVGtIWIjWcznhaop6XN6HxnOL8800hF6CBNvlqQ=",
+        "lastModified": 1780515920,
+        "narHash": "sha256-8KX2hEeOX6KP3hBBJJI8dGWVrzbOOf1rBPmg/GUG24U=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7d8127d308c3fb9664f7e643eec944be74ebb37d",
+        "rev": "4c5c1e8ba14f1c7475fa31ff11bc1c19cd220974",
         "type": "github"
       },
       "original": {
@@ -336,11 +336,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1780065812,
-        "narHash": "sha256-SCSLUKBmwlSLGQ8Xbr8PjRFtiHNk0l9ktqkcmqdBkfE=",
+        "lastModified": 1780310866,
+        "narHash": "sha256-fPBRVf6A5xlACYcOI59shGrjURuvwu0lRsDoSCEXt/I=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "b76b5639c0593e0aeb0b5879ad62d4b30596c144",
+        "rev": "4ed851c979641e28597a05086332d75cdc9e395f",
         "type": "github"
       },
       "original": {
@@ -413,11 +413,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1780030872,
-        "narHash": "sha256-u6WU/yd/o8iYQrHX3RAwO1hYa3LkoSL+WNQD0rJfJZQ=",
+        "lastModified": 1780365719,
+        "narHash": "sha256-QfWfccTN+70ZQ4m2qlU9PiKfz2Yppq94058iJyARNwc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e9a7635a57597d9754eccebdfc7045e6c8600e6b",
+        "rev": "ffa10e26ae11d676b2db836259889f1f571cb14f",
         "type": "github"
       },
       "original": {
@@ -429,11 +429,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1779560665,
-        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
         "type": "github"
       },
       "original": {
@@ -449,11 +449,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1780306790,
-        "narHash": "sha256-LaTUxSbBURzW5YA2+u0PwmLgYPcqrZV/A0J7ykRhkq8=",
+        "lastModified": 1780564544,
+        "narHash": "sha256-ljk/86ypsH2sQGaAMryirHKA6fpu2tRcLpv8hSW+rqY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "eefb5871eb28556b65bc1ba20600b2500aa00640",
+        "rev": "926abe90eb6743953a6acdb3463ee510db6aa0c6",
         "type": "github"
       },
       "original": {
@@ -588,11 +588,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1780305387,
-        "narHash": "sha256-ONKWobejhq1WG0LKgquVihGIQFa+FtOmivcbxmNt7ek=",
+        "lastModified": 1780420761,
+        "narHash": "sha256-/JB8GTpIgn9/Osi3pQG2yDZnIrX+YdbdATn3Psciboo=",
         "owner": "oraios",
         "repo": "serena",
-        "rev": "81fafd646e8097dd34c7938c5a48fcf17bf983db",
+        "rev": "c9abd9f793b0f3ab8abb056a26011bb75e0bc5a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated update of `flake.lock` inputs.

All hosts built successfully against this lock file.
Merging will trigger `autodeploy.yaml`, which publishes store paths for pickup by `nixos-autodeploy`.

## Package changes

**Added: 0
0 | Removed: 1 | Changed: **

<details>
<summary>Full diff</summary>

```
accountsservice: 23.13.9 → 26.13.3, [31;1m22.9 KiB[0m
ayatana-ido: ∅ → 0.10.4, [31;1m228.5 KiB[0m
btrfs-progs: 6.19.1 → 7.0, [31;1m25.3 KiB[0m
claude-code: 2.1.154 → 2.1.158, [31;1m240.0 KiB[0m
crush: 0.74.1 → 0.75.0, [31;1m466.6 KiB[0m
dhcpcd: 10.3.1 → 10.3.2
doggo: 1.1.6 → 1.1.7, [31;1m15.9 KiB[0m
fc: [31;1m186.0 KiB[0m
ffmpeg: 7.1.3 → 7.1.4, [31;1m12.0 KiB[0m
firefox-unwrapped: [32;1m-33.7 KiB[0m
fuse: [32;1m-315.4 KiB[0m
fwupd: 2.1.1 → 2.1.4, [31;1m730.0 KiB[0m
hm_.configzsh.zprofile: ∅ → ε
iceauth: 1.0.10 → 1.0.11
initrd-linux: 6.18.33 → 6.18.34
initrd-linux: 6.18.33 → 6.18.34, [32;1m-28.5 KiB[0m
initrd-linux: 6.18.33 → 6.18.34, [32;1m-9.1 KiB[0m
iperf: 3.20 → 3.21, [31;1m8.6 KiB[0m
kitty: 0.47.0 → 0.47.1, [31;1m33.5 KiB[0m
libayatana-appindicator: ∅ → 0.5.92, [31;1m78.5 KiB[0m
libayatana-indicator: ∅ → 0.9.4, [31;1m154.1 KiB[0m
libblockdev: 3.4.0 → 3.5.0, [31;1m46.8 KiB[0m
libgit2: 1.9.3 → 1.9.4
linux: 6.18.33 → 6.18.34, [32;1m-97.8 KiB[0m
mise: 2026.5.12 → 2026.5.15, [31;1m297.1 KiB[0m
nixos-manual: [31;1m23.5 KiB[0m
nixos-rebuild-ng: [31;1m51.4 KiB[0m
nixos-system-kushtaka: 26.11.20260529.e9a7635 → 26.11.20260602.ffa10e2
nixos-system-snallygaster: 26.11.20260529.e9a7635 → 26.11.20260602.ffa10e2
nixos-system-wendigo: 26.11.20260529.e9a7635 → 26.11.20260602.ffa10e2
noto-fonts-cjk-sans: ∅ → 2.004, [31;1m61.6 MiB[0m
noto-fonts-cjk-serif: ∅ → 2.003, [31;1m54.8 MiB[0m
ntfs3g: [31;1m147.1 KiB[0m
obsidian: [31;1m103.9 KiB[0m
pycairo: ∅ → 1.29.0
pygobject: ∅ → 3.56.2
python3.11-pycairo: ∅ → 1.29.0, [31;1m511.8 KiB[0m
python3.11-pygobject: ∅ → 3.56.2, [31;1m1.2 MiB[0m
ruff: 0.15.14 → 0.15.15, [32;1m-239.9 KiB[0m
serena-agent: [31;1m12.1 KiB[0m
serena: [31;1m21.6 KiB[0m
source: [31;1m247.8 KiB[0m
wireless-regdb: 2026.02.04 → 2026.05.30
x86_energy_perf_policy: 6.18.33 → 6.18.34
```

</details>