### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -56,11 +56,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1780436821,
-        "narHash": "sha256-iXo+zR2pUChuMwvqtG9GRiabLAsUC4xtdw+R7tFxSMA=",
+        "lastModified": 1780693213,
+        "narHash": "sha256-l01lsdTduPsWJqkfG1tTv1LaLEYrAsIvgTJilkGc1rA=",
         "owner": "charmbracelet",
         "repo": "nur",
-        "rev": "6395f6f83d297eff07986ab320aa514f39d2b096",
+        "rev": "9b0267457cdd1be6978b9618bed2dfd85732f152",
         "type": "github"
       },
       "original": {
@@ -236,11 +236,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780593650,
-        "narHash": "sha256-CHo7k65YTL3HY+WQVedDTupji+LMgNlKCdrtRHZFAK4=",
+        "lastModified": 1780679734,
+        "narHash": "sha256-KmRNvpNOb7QEORa06bVgjW9kITcx0VhsI7w0vhmZyD8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "447fd9ff62501dae7206dfe180ee89f8de27b7d5",
+        "rev": "b2b7db486e06e098711dc291bb25db82850e1d16",
         "type": "github"
       },
       "original": {
@@ -275,11 +275,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780210899,
-        "narHash": "sha256-4axz3OBPTKa6LIkXV8n0lc63MQU+et2CB5DGobEAi6k=",
+        "lastModified": 1780816331,
+        "narHash": "sha256-0BYqs8yKWkOz2Q7+SP18N5E5gmDKSo6LSxIVIa0wWes=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "97df9dc0b7c924344b793a15c1e8e4522ebb854e",
+        "rev": "1a2ea89c917781e88508d9fd2b507f2d2a0e173c",
         "type": "github"
       },
       "original": {
@@ -394,11 +394,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1780365719,
-        "narHash": "sha256-QfWfccTN+70ZQ4m2qlU9PiKfz2Yppq94058iJyARNwc=",
+        "lastModified": 1780747962,
+        "narHash": "sha256-IX7G1dlKrOqPOImfbo7ADDfV5yU1+j+MRChI3TL4tAA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ffa10e26ae11d676b2db836259889f1f571cb14f",
+        "rev": "cbb5cf358f50aa6acc9efd6113b7bcfbc352cd73",
         "type": "github"
       },
       "original": {
@@ -430,11 +430,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1780610002,
-        "narHash": "sha256-fs7BSbFfY/THpCkgCDauvO0ArU88TKnorFQoa+mOD6o=",
+        "lastModified": 1780822363,
+        "narHash": "sha256-U14O2/+Qu3UAiBV5T93oJXz3+g9+RGV6Gq+gR8oBcGk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "50eb2f91b625e1037b2ffe1117b9f7ab5d4a1442",
+        "rev": "126c9d9b7edcf27577ad7febf13cf11a1e190418",
         "type": "github"
       },
       "original": {
@@ -569,11 +569,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1780420761,
-        "narHash": "sha256-/JB8GTpIgn9/Osi3pQG2yDZnIrX+YdbdATn3Psciboo=",
+        "lastModified": 1780670814,
+        "narHash": "sha256-TiGo5o3nUCI2rUqY6MhnzASeCe65nOlQNQZf2kY0f1k=",
         "owner": "oraios",
         "repo": "serena",
-        "rev": "c9abd9f793b0f3ab8abb056a26011bb75e0bc5a3",
+        "rev": "1931b601efcb0ae1a7c32e0382b3d4085fbaa4a4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated update of `flake.lock` inputs.

All hosts built successfully against this lock file.
Merging will trigger `autodeploy.yaml`, which publishes store paths for pickup by `nixos-autodeploy`.

## Package changes

**Added: 0
0 | Removed: 0
0 | Changed: **

<details>
<summary>Full diff</summary>

```
1password: 8.12.21 → 8.12.22, [31;1m2.7 MiB[0m
akonadi-calendar: 26.04.1 → 26.04.2
akonadi-contacts: 26.04.1 → 26.04.2
akonadi-mime: 26.04.1 → 26.04.2
akonadi-search: 26.04.1 → 26.04.2
akonadi: 26.04.1 → 26.04.2
ark: 26.04.1 → 26.04.2
baloo-widgets: 26.04.1 → 26.04.2
boringssl: 0.20260508.0 → 0.20260526.0, [31;1m38.9 KiB[0m
claude-code: 2.1.158 → 2.1.161, [31;1m2.6 MiB[0m
crush: 0.75.0 → 0.76.0, [31;1m102.0 KiB[0m
dolphin-plugins: 26.04.1 → 26.04.2
dolphin: 26.04.1 → 26.04.2, [31;1m16.9 KiB[0m
elisa: 26.04.1 → 26.04.2
ffmpegthumbs: 26.04.1 → 26.04.2
firefox-unwrapped: 151.0.2 → 151.0.3, [31;1m370.3 KiB[0m
firefox: 151.0.2 → 151.0.3
grantleetheme: 26.04.1 → 26.04.2
gwenview: 26.04.1 → 26.04.2
index-x86_64: [31;1m150.6 KiB[0m
jujutsu: 0.41.0 → 0.42.0, [31;1m210.6 KiB[0m
kaccounts-integration: 26.04.1 → 26.04.2
kate: 26.04.1 → 26.04.2
kcalutils: 26.04.1 → 26.04.2
kde-inotify-survey: 26.04.1 → 26.04.2
kdegraphics-mobipocket: 26.04.1 → 26.04.2
kdegraphics-thumbnailers: 26.04.1 → 26.04.2
kdepim-runtime: 26.04.1 → 26.04.2
khelpcenter: 26.04.1 → 26.04.2
kidentitymanagement: 26.04.1 → 26.04.2
kimap: 26.04.1 → 26.04.2
kio-admin: 26.04.1 → 26.04.2
kio-extras: 26.04.1 → 26.04.2
kldap: 26.04.1 → 26.04.2
kmailtransport: 26.04.1 → 26.04.2
kmbox: 26.04.1 → 26.04.2
kmime: 26.04.1 → 26.04.2
konsole: 26.04.1 → 26.04.2
kpimtextedit: 26.04.1 → 26.04.2
ksmtp: 26.04.1 → 26.04.2
kunifiedpush: 26.04.1 → 26.04.2
kwalletmanager: 26.04.1 → 26.04.2
libXNVCtrl: 595.71.05 → 595.80
libappimage: [32;1m-45.7 KiB[0m
libgravatar: 26.04.1 → 26.04.2
libinput: 1.31.1 → 1.31.3
libjcat: 0.2.3 → 0.2.6, [31;1m9.1 KiB[0m
libkdcraw: 26.04.1 → 26.04.2
libkdepim: 26.04.1 → 26.04.2
libkexiv2: 26.04.1 → 26.04.2
libkgapi: 26.04.1 → 26.04.2
libkleo: 26.04.1 → 26.04.2
libwacom: 2.18.0 → 2.19.0, [31;1m27.0 KiB[0m
mesa: 26.1.1 → 26.1.2, [31;1m18.2 KiB[0m
mesa: 26.1.1 → 26.1.2, [31;1m29.1 KiB[0m
messagelib: 26.04.1 → 26.04.2
nixos-manual: [31;1m31.2 KiB[0m
nixos-system-kushtaka: 26.11.20260602.ffa10e2 → 26.11.20260606.cbb5cf3
nixos-system-snallygaster: 26.11.20260602.ffa10e2 → 26.11.20260606.cbb5cf3
nixos-system-wendigo: 26.11.20260602.ffa10e2 → 26.11.20260606.cbb5cf3
noto-fonts: 2026.05.01 → 2026.06.01
okular: 26.04.1 → 26.04.2
pimcommon: 26.04.1 → 26.04.2
python3.13-sentry-sdk: 2.60.0 → 2.61.1, [31;1m161.1 KiB[0m
qrca: 26.04.1 → 26.04.2
signal-desktop: 8.9.1 → 8.13.0, [32;1m-1.3 MiB[0m
source: [31;1m319.8 KiB[0m
squashfuse: 0.6.1 → 0.6.2, [31;1m195.8 KiB[0m
tailscale: 1.98.3 → 1.98.5
vimplugin-ale: 4.0.0-unstable-2026-05-28 → 4.0.0-unstable-2026-06-01
vimplugin-fzf.vim: 0-unstable-2026-05-24 → 0-unstable-2026-06-02
vimplugin-luajit2.1-lualine.nvim-scm: 4-unstable-scm-4 → 5-unstable-scm-5
xorg-server: 21.1.22 → 21.1.23
xwayland: 24.1.11 → 24.1.12
zsh: 5.9 → 5.9.1, [31;1m437.0 KiB[0m
```

</details>