### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -236,11 +236,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781129616,
-        "narHash": "sha256-Hl0Pz/QIKpePSU7SdK3BMe5VNmUhFvfWyg57GyawxzE=",
+        "lastModified": 1781305496,
+        "narHash": "sha256-g8Vv4Qfc7n+lgov97REu3X6BeJtvYY0hlSUZR1GrGQQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7dbd305f8b81050f223f00bcfbc8a6b74e048806",
+        "rev": "c87a39aa979acc4848016d2220c6238390d84779",
         "type": "github"
       },
       "original": {
@@ -317,11 +317,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1781020964,
-        "narHash": "sha256-fS7xTi2j2iso5Hj7RNZLv/acDlCT+fgMVkVk40A7Uco=",
+        "lastModified": 1781168557,
+        "narHash": "sha256-LOnLQ2tpYF9gqIDDr3+j3DbpJJr/QCH6zPRT2GzEUOE=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "32c2cd9e46286c4eced3dc6b613c659126bf3cca",
+        "rev": "6358ff76821101c178e3ab4919a62799bfe3652e",
         "type": "github"
       },
       "original": {
@@ -394,11 +394,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1780930886,
-        "narHash": "sha256-rppURzHviaQN131F+nLiLdGfcb0uCd9gGP0E5+iw9MI=",
+        "lastModified": 1781268102,
+        "narHash": "sha256-Zn5KTggEmUB3lXn/ccERNcBdddE6IaOFber9dWViWDg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8c3cede7ddc26bd659d2d383b5610efbd2c7a16e",
+        "rev": "49a4bd0573c376468dd7996ddb6f9fa31d8c4d97",
         "type": "github"
       },
       "original": {
@@ -410,11 +410,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1780749050,
-        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
+        "lastModified": 1781074563,
+        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
+        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
         "type": "github"
       },
       "original": {
@@ -430,11 +430,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1781132811,
-        "narHash": "sha256-fIWkmQH5g0ajB50KSTrznyQQWmL95NIimW+JXUUEHbk=",
+        "lastModified": 1781340123,
+        "narHash": "sha256-Y39ICCPQPn7KBWln+vMucanz5ChmdfsQDEVR73inBp4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4a0a9f423837163e2a70b9b18e3bd2605a3718f9",
+        "rev": "b94e5623699fcdf24120733077597d263836819e",
         "type": "github"
       },
       "original": {
@@ -569,11 +569,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1781000272,
-        "narHash": "sha256-RdB2nxjUSsQEjE3HPN945PKcDIEdZfOv3v8BBxlDFDk=",
+        "lastModified": 1781304002,
+        "narHash": "sha256-aD0Yvec7EXEHGsw09HMUyCJpuq9kDKqgpkPPzohy2FA=",
         "owner": "oraios",
         "repo": "serena",
-        "rev": "1d020b96069435310613d07211ced178e1fdaf78",
+        "rev": "22c135a881aaf17485e54ef0ccaedeaf51a202c0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated update of `flake.lock` inputs.

All hosts built successfully against this lock file.
Merging will trigger `autodeploy.yaml`, which publishes store paths for pickup by `nixos-autodeploy`.

## Package changes

**Added: 0
0 | Removed: 1 | Changed: **

<details>
<summary>Full diff</summary>

```
1password-cli: 2.34.0 → 2.34.1, [32;1m-12.0 KiB[0m
attica: 6.26.0 → 6.27.0
baloo: 6.26.0 → 6.27.0, [31;1m13.1 KiB[0m
bluez-qt: 6.26.0 → 6.27.0
bootspec: 2.0.0 → ∅, [32;1m-1.9 MiB[0m
breeze-icons: 6.26.0 → 6.27.0, [32;1m-162.4 KiB[0m
comma: [31;1m10.2 KiB[0m
discount: 3.0.1.2 → 3.0.1.3
docker-containerd: 29.5.2 → 29.5.3, [31;1m16.0 KiB[0m
docker-runc: 29.5.2 → 29.5.3
docker-tini: 29.5.2 → 29.5.3
docker: 29.5.2 → 29.5.3, [32;1m-500.2 KiB[0m
electron-unwrapped: 40.10.2, 41.7.1 → 40.10.3, 41.7.2, [31;1m12.0 KiB[0m
electron: 40.10.2, 41.7.1 → 40.10.3, 41.7.2
firefox-unwrapped: 151.0.3 → 151.0.4, [32;1m-362.7 KiB[0m
firefox: 151.0.3 → 151.0.4
frameworkintegration: 6.26.0 → 6.27.0
fuse-overlayfs: 1.16 → 1.17
gh: 2.93.0 → 2.94.0, [31;1m331.4 KiB[0m
gnupg: [31;1m1.2 MiB[0m
initrd-linux: 6.18.34 → 6.18.35
initrd-linux: 6.18.34 → 6.18.35, [31;1m10.8 KiB[0m
karchive: 6.26.0 → 6.27.0
kauth: 6.26.0 → 6.27.0, [31;1m18.2 KiB[0m
kbookmarks: 6.26.0 → 6.27.0
kcalendarcore: 6.26.0 → 6.27.0
kcmutils: 6.26.0 → 6.27.0, [31;1m8.3 KiB[0m
kcodecs: 6.26.0 → 6.27.0
kcolorscheme: 6.26.0 → 6.27.0
kcompletion: 6.26.0 → 6.27.0
kconfig: 6.26.0 → 6.27.0, [31;1m20.9 KiB[0m
kconfigwidgets: 6.26.0 → 6.27.0
kcontacts: 6.26.0 → 6.27.0, [31;1m8.2 KiB[0m
kcoreaddons: 6.26.0 → 6.27.0, [31;1m97.0 KiB[0m
kcrash: 6.26.0 → 6.27.0
kdav: 6.26.0 → 6.27.0, [31;1m27.3 KiB[0m
kdbusaddons: 6.26.0 → 6.27.0
kdeclarative: 6.26.0 → 6.27.0, [32;1m-13.1 KiB[0m
kded: 6.26.0 → 6.27.0
kdesu: 6.26.0 → 6.27.0
kdnssd: 6.26.0 → 6.27.0
kdoctools: 6.26.0 → 6.27.0
kfilemetadata: 6.26.0 → 6.27.0
kglobalaccel: 6.26.0 → 6.27.0
kguiaddons: 6.26.0 → 6.27.0, [31;1m42.3 KiB[0m
kholidays: 6.26.0 → 6.27.0, [31;1m22.3 KiB[0m
ki18n: 6.26.0 → 6.27.0
kiconthemes: 6.26.0 → 6.27.0
kidletime: 6.26.0 → 6.27.0
kimageformats: 6.26.0 → 6.27.0, [31;1m111.3 KiB[0m
kio: 6.26.0 → 6.27.0, [31;1m197.2 KiB[0m
kirigami-addons: [31;1m21.4 KiB[0m
kirigami: 6.26.0 → 6.27.0, [31;1m183.4 KiB[0m
kitemmodels: 6.26.0 → 6.27.0
kitemviews: 6.26.0 → 6.27.0
kitty: 0.47.1 → 0.47.2, [31;1m156.7 KiB[0m
kjobwidgets: 6.26.0 → 6.27.0
knewstuff: 6.26.0 → 6.27.0
knotifications: 6.26.0 → 6.27.0
knotifyconfig: 6.26.0 → 6.27.0
kpackage: 6.26.0 → 6.27.0
kparts: 6.26.0 → 6.27.0
kpty: 6.26.0 → 6.27.0
kquickcharts: 6.26.0 → 6.27.0
krunner: 6.26.0 → 6.27.0, [31;1m32.6 KiB[0m
kservice: 6.26.0 → 6.27.0
kstatusnotifieritem: 6.26.0 → 6.27.0
ksvg: 6.26.0 → 6.27.0, [31;1m18.6 KiB[0m
ktexteditor: 6.26.0 → 6.27.0, [31;1m14.6 KiB[0m
ktexttemplate: 6.26.0 → 6.27.0
ktextwidgets: 6.26.0 → 6.27.0
kunitconversion: 6.26.0 → 6.27.0, [32;1m-19.8 KiB[0m
kuserfeedback: 6.26.0 → 6.27.0
kwallet: 6.26.0 → 6.27.0, [31;1m29.3 KiB[0m
kwidgetsaddons: 6.26.0 → 6.27.0, [31;1m12.5 KiB[0m
kwindowsystem: 6.26.0 → 6.27.0
kxmlgui: 6.26.0 → 6.27.0, [31;1m35.4 KiB[0m
libplasma: [31;1m12.9 KiB[0m
libslirp: 4.9.1 → 4.9.3, [31;1m8.1 KiB[0m
linux: 6.18.34 → 6.18.35, [31;1m314.7 KiB[0m
milou: [31;1m67.7 KiB[0m
moby: 29.5.2 → 29.5.3
modemmanager-qt: 6.26.0 → 6.27.0
mslex: ∅ → 1.3.0, [31;1m37.8 KiB[0m
neovim-unwrapped: 0.12.2 → 0.12.3, [31;1m70.3 KiB[0m
neovim: 0.12.2 → 0.12.3
networkmanager-qt: 6.26.0 → 6.27.0
networkmanager.conf: ∅ → ε
nixos-manual: [32;1m-13.9 KiB[0m
nixos-system-kushtaka: 26.11.20260608.8c3cede → 26.11.20260612.49a4bd0
nixos-system-snallygaster: 26.11.20260608.8c3cede → 26.11.20260612.49a4bd0
nixos-system-wendigo: 26.11.20260608.8c3cede → 26.11.20260612.49a4bd0
onnxruntime: [31;1m98.3 KiB[0m
oslex: ∅ → 2.0.0, [31;1m28.1 KiB[0m
oxygen-icons: 6.2.0 → 6.27.0
perl5.42.0-DBI: 1.644 → 1.648
plasma-keyboard: [31;1m47.8 KiB[0m
prison: 6.26.0 → 6.27.0
purpose: 6.26.0 → 6.27.0, [31;1m139.1 KiB[0m
qqc2-desktop-style: 6.26.0 → 6.27.0
rclone: 1.74.2 → 1.74.3, [31;1m13.2 KiB[0m
ruff: 0.15.15 → 0.15.16, [31;1m9.9 KiB[0m
serena-agent: [31;1m11.4 KiB[0m
solid: 6.26.0 → 6.27.0, [31;1m22.3 KiB[0m
sonnet: 6.26.0 → 6.27.0, [31;1m15.6 KiB[0m
source: [31;1m310.0 KiB[0m
spectacle: [31;1m39.7 KiB[0m
starlette: 1.0.0 → 1.0.1
strongswan: 6.0.6 → 6.0.7, [31;1m8.4 KiB[0m
syndication: 6.26.0 → 6.27.0
syntax-highlighting: 6.26.0 → 6.27.0
threadweaver: 6.26.0 → 6.27.0
tree-sitter-c-neovim: 0.12.2 → 0.12.3
tree-sitter-lua-neovim: 0.12.2 → 0.12.3
tree-sitter-markdown-neovim: 0.12.2 → 0.12.3
tree-sitter-markdown_inline-neovim: 0.12.2 → 0.12.3
tree-sitter-query-neovim: 0.12.2 → 0.12.3
tree-sitter-vim-neovim: 0.12.2 → 0.12.3
tree-sitter-vimdoc-neovim: 0.12.2 → 0.12.3
vimplugin-nvim-lspconfig: 2.9.0 → 2.10.0, [31;1m35.5 KiB[0m
vimplugin-nvim-surround: 4.0.5-unstable-2026-05-02 → 4.0.5-unstable-2026-06-08
vimplugin-nvim-tree.lua: 1.17.0-unstable-2026-05-15 → 1.17.0-unstable-2026-06-08
x86_energy_perf_policy: 6.18.34 → 6.18.35
xfsprogs: 6.19.0 → 7.0.1, [31;1m156.9 KiB[0m
```

</details>