### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -56,11 +56,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1780693213,
-        "narHash": "sha256-l01lsdTduPsWJqkfG1tTv1LaLEYrAsIvgTJilkGc1rA=",
+        "lastModified": 1781552847,
+        "narHash": "sha256-tgCHvCebZyWZYuycIiBQ6+Z2k7A29jy2tTDZepaEVik=",
         "owner": "charmbracelet",
         "repo": "nur",
-        "rev": "9b0267457cdd1be6978b9618bed2dfd85732f152",
+        "rev": "77427868f410528812b9493bb2d4c9094937d054",
         "type": "github"
       },
       "original": {
@@ -236,11 +236,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781305496,
-        "narHash": "sha256-g8Vv4Qfc7n+lgov97REu3X6BeJtvYY0hlSUZR1GrGQQ=",
+        "lastModified": 1781557312,
+        "narHash": "sha256-QOIRYSUFSq7L5mY3dZymaVhcnne3tPgoR9riB0WocjA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c87a39aa979acc4848016d2220c6238390d84779",
+        "rev": "c03e4752899e55705dfa63979abd885c582a5c48",
         "type": "github"
       },
       "original": {
@@ -275,11 +275,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780816331,
-        "narHash": "sha256-0BYqs8yKWkOz2Q7+SP18N5E5gmDKSo6LSxIVIa0wWes=",
+        "lastModified": 1781422160,
+        "narHash": "sha256-W7S8O86bVrw2gaomEwkHStOzmPpnFIHQ6lS4Q2HffJ0=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "1a2ea89c917781e88508d9fd2b507f2d2a0e173c",
+        "rev": "854d04e2368fb2e9c328a36b3c0a04cd713bfae1",
         "type": "github"
       },
       "original": {
@@ -394,11 +394,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1781268102,
-        "narHash": "sha256-Zn5KTggEmUB3lXn/ccERNcBdddE6IaOFber9dWViWDg=",
+        "lastModified": 1781454065,
+        "narHash": "sha256-d2xfDjnfRuf/xYGdu9VVRHiav/2w5hDL/5cw2TuVAXw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "49a4bd0573c376468dd7996ddb6f9fa31d8c4d97",
+        "rev": "9eac87a12312b8f60dd52e1c6e1a265f6fc7f5fc",
         "type": "github"
       },
       "original": {
@@ -430,11 +430,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1781340123,
-        "narHash": "sha256-Y39ICCPQPn7KBWln+vMucanz5ChmdfsQDEVR73inBp4=",
+        "lastModified": 1781602565,
+        "narHash": "sha256-sWeGr2JtgjEjBTSKzYyffzOUyvfy5F9iL0JF4Mk7gjk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b94e5623699fcdf24120733077597d263836819e",
+        "rev": "4b57f44aea11b7a4c26721d19987ad508a844922",
         "type": "github"
       },
       "original": {
@@ -569,11 +569,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1781304002,
-        "narHash": "sha256-aD0Yvec7EXEHGsw09HMUyCJpuq9kDKqgpkPPzohy2FA=",
+        "lastModified": 1781518176,
+        "narHash": "sha256-Jle852Ag7NPG5sE+FbRk3wqkWIHUPDIgZPcCo9ssSIQ=",
         "owner": "oraios",
         "repo": "serena",
-        "rev": "22c135a881aaf17485e54ef0ccaedeaf51a202c0",
+        "rev": "652a739826b9f54a0161fd2cf385c3259db24f32",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated update of `flake.lock` inputs.

All hosts built successfully against this lock file.
Merging will trigger `autodeploy.yaml`, which publishes store paths for pickup by `nixos-autodeploy`.

## Package changes

**Added: 0
0 | Removed: 0
0 | Changed: **

<details>
<summary>Full diff</summary>

```
crush: 0.76.0 → 0.77.0, [31;1m53.6 KiB[0m
dnsmasq: 2.92rel2 → 2.93, [31;1m15.1 KiB[0m
dnsmasq: 2.92rel2 → 2.93, [31;1m29.7 KiB[0m
fwupd: 2.1.4 → 2.1.5, [31;1m203.2 KiB[0m
index-x86_64: [31;1m438.8 KiB[0m
kitty-themes: 0-unstable-2026-03-31 → 0-unstable-2026-06-08, [31;1m39.2 KiB[0m
libsigc++: 3.6.0 → 3.8.1
nixos-manual: [32;1m-10.3 KiB[0m
nixos-system-kushtaka: 26.11.20260612.49a4bd0 → 26.11.20260614.9eac87a
nixos-system-snallygaster: 26.11.20260612.49a4bd0 → 26.11.20260614.9eac87a
nixos-system-wendigo: 26.11.20260612.49a4bd0 → 26.11.20260614.9eac87a
source: [32;1m-72.3 KiB[0m
```

</details>