### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -236,11 +236,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781557312,
-        "narHash": "sha256-QOIRYSUFSq7L5mY3dZymaVhcnne3tPgoR9riB0WocjA=",
+        "lastModified": 1781844424,
+        "narHash": "sha256-sWBr0D6eu6UhmtM87NOd4oOYilIclFXGDd/s7tVvO10=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c03e4752899e55705dfa63979abd885c582a5c48",
+        "rev": "c804fab681f03ec772390af4421bcc9bce80c1d9",
         "type": "github"
       },
       "original": {
@@ -317,11 +317,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1781168557,
-        "narHash": "sha256-LOnLQ2tpYF9gqIDDr3+j3DbpJJr/QCH6zPRT2GzEUOE=",
+        "lastModified": 1781622756,
+        "narHash": "sha256-JrPh4M6S7aPsEE9tOENuZrxC6o2szSLlK+t4+nLke9s=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "6358ff76821101c178e3ab4919a62799bfe3652e",
+        "rev": "08018c72174a4df5657f8d94178ac69fb9c243e5",
         "type": "github"
       },
       "original": {
@@ -394,11 +394,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1781454065,
-        "narHash": "sha256-d2xfDjnfRuf/xYGdu9VVRHiav/2w5hDL/5cw2TuVAXw=",
+        "lastModified": 1781607440,
+        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9eac87a12312b8f60dd52e1c6e1a265f6fc7f5fc",
+        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
         "type": "github"
       },
       "original": {
@@ -410,11 +410,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1781074563,
-        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
         "type": "github"
       },
       "original": {
@@ -430,11 +430,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1781602565,
-        "narHash": "sha256-sWeGr2JtgjEjBTSKzYyffzOUyvfy5F9iL0JF4Mk7gjk=",
+        "lastModified": 1781861468,
+        "narHash": "sha256-mkuHmYDMUeRTdXPdbHe1Jzc5kJODikx8XdupEcSQISI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4b57f44aea11b7a4c26721d19987ad508a844922",
+        "rev": "85b70df58b44975f9fb14161bf49e85ea5490ffe",
         "type": "github"
       },
       "original": {
@@ -569,11 +569,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1781518176,
-        "narHash": "sha256-Jle852Ag7NPG5sE+FbRk3wqkWIHUPDIgZPcCo9ssSIQ=",
+        "lastModified": 1781621781,
+        "narHash": "sha256-KIF+P5bBhoYo6MhLUz2HpLD7HCXra3AYUoftdWwEHkw=",
         "owner": "oraios",
         "repo": "serena",
-        "rev": "652a739826b9f54a0161fd2cf385c3259db24f32",
+        "rev": "dd7eb6d72ae179aa940e50cd6276ec5646f306f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated update of `flake.lock` inputs.

All hosts built successfully against this lock file.
Merging will trigger `autodeploy.yaml`, which publishes store paths for pickup by `nixos-autodeploy`.

## Package changes

**Added: 4 | Removed: 2 | Changed: 16**

<details>
<summary>Full diff</summary>

```
fc: ∅ → 53-user-aliases.conf
firefox-unwrapped: 151.0.4 → 152.0, [31;1m3.7 MiB[0m
firefox: 151.0.4 → 152.0, [32;1m-398.4 KiB[0m
hm_fontconfigconf.d10hmfonts.conf: ε → ∅
hm_fontconfigconf.d52hmdefaultfonts.conf: ε → ∅
hm_hmfontconfigdefaultfonts.xml: ∅ → ε
hm_hmfontconfigfonts.xml: ∅ → ε
home-configuration-reference: [31;1m15.1 KiB[0m
initrd-linux: [32;1m-23.7 KiB[0m
initrd-linux: [32;1m-9.7 KiB[0m
kitty: 0.47.2 → 0.47.4, [31;1m559.3 KiB[0m
mise: 2026.6.0 → 2026.6.5, [31;1m2.0 MiB[0m
nixos-firewall-tool: ∅ → 26.11
nixos-firewall: ε → ∅
nixos-manual: [31;1m11.7 KiB[0m
nixos-system-kushtaka: 26.11.20260614.9eac87a → 26.11.20260616.3e41b24
nixos-system-snallygaster: 26.11.20260614.9eac87a → 26.11.20260616.3e41b24
nixos-system-wendigo: 26.11.20260614.9eac87a → 26.11.20260616.3e41b24
nss: 3.124 → 3.125
ruff: 0.15.16 → 0.15.17, [31;1m513.5 KiB[0m
security-wrapper-pkexec-x86_64-unknown-linux: ε → ∅, [32;1m-70.0 KiB[0m
source: [31;1m798.4 KiB[0m
```

</details>