### PR TITLE
chore: update claude-code

### DIFF
--- a/pkgs/claude-code/default.nix
+++ b/pkgs/claude-code/default.nix
@@ -11,7 +11,7 @@
   callPackage,
   binName ? "claude",
 }: let
-  version = "2.1.185";
+  version = "2.1.186";
 
   platformMap = {
     "aarch64-darwin" = "darwin-arm64";
@@ -25,10 +25,10 @@
       or (throw "claude-code: unsupported platform ${stdenv.hostPlatform.system}");
 
   nativeHashes = {
-    "darwin-arm64" = "1w8avkx4n12mjdd5q5qhfkhbk2dwklf00vyqbf7j298544xw5052";
-    "darwin-x64" = "1xvswzwhr9x9df5wzk97rfzgfw54dgfvr05crns59xr760ya3rxd";
-    "linux-x64" = "0lir62y47bbdkkkbs505issbm86p9rnkzvkxc87fw14zd4w66971";
-    "linux-arm64" = "1y5j5hk0laz6z3mrq8acd3d0wdzrmlpxjq1iyxfla1154w90i26v";
+    "darwin-arm64" = "0dw6lz6y84ml1cgz8xxh32695zrdkvnb8q9k3gzpqy596k67jfj6";
+    "darwin-x64" = "16cqgkvhi9hz15awh5r6a446in7g4lfnqlxryi6cdfqw8lyy45wy";
+    "linux-x64" = "0adk3hx3xn68m4lrxx6vrqnwvyx0r9l9n74l70qwk5v590imsvba";
+    "linux-arm64" = "1dhwjq996y0jx5v5g2i4fzgcm44ikdxk3gkij727i2snhgs5yzl1";
   };
 
   nativeBinary = fetchurl {


### PR DESCRIPTION
Automated update of `pkgs/claude-code` to the latest version published on npm.

The new binary has been built and pushed to Cachix — no local build required after merge.