### PR TITLE
chore: update claude-code

### DIFF
--- a/pkgs/claude-code/default.nix
+++ b/pkgs/claude-code/default.nix
@@ -11,7 +11,7 @@
   callPackage,
   binName ? "claude",
 }: let
-  version = "2.1.195";
+  version = "2.1.196";
 
   platformMap = {
     "aarch64-darwin" = "darwin-arm64";
@@ -25,10 +25,10 @@
       or (throw "claude-code: unsupported platform ${stdenv.hostPlatform.system}");
 
   nativeHashes = {
-    "darwin-arm64" = "1bbnb24vqxw65h95rc2f95x3glwzn6a48w9yyfasndpkjfnssicb";
-    "darwin-x64" = "0q3w50d1nvv5xk7zlmx4zhvhha9njd9971qm2f6jfskfdmp73f3y";
-    "linux-x64" = "0dva7v043a59is1mplpzf9g7xa1mv12pg5cb8yj4fc864l0yf8w3";
-    "linux-arm64" = "16ky98hn33dck89q8bs92n31fnjls5ir9ly5w6h81p2qj2cpj8mh";
+    "darwin-arm64" = "0nhg0wq3mpfyr6gmif8c71livsbrkw6zjpr287r2nb2qnwdfdikg";
+    "darwin-x64" = "1q0ydn4shp86h6lv556js05lg40wn5nc93v3x9xag73vw9k4virj";
+    "linux-x64" = "1pmsgg1ywdxs6h7vpqzpjl9vsch9bjfh02dshfdvhkaksmnkr4zb";
+    "linux-arm64" = "1n2dznkbvrbc8l26gxdgb4ancghrk7baq24nr8hykl9msf4r3ah5";
   };
 
   nativeBinary = fetchurl {


### PR DESCRIPTION
Automated update of `pkgs/claude-code` to the latest version published on npm.

The new binary has been built and pushed to Cachix — no local build required after merge.