### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -56,11 +56,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1782476353,
-        "narHash": "sha256-8SnmbRtSgVBTdj5/mH1Rna4zJ/qTyGFGLpSivwAVuss=",
+        "lastModified": 1782822334,
+        "narHash": "sha256-dNh489qzsUf2QvliQk5jnc9+fdIyPJs2185/vNSShKg=",
         "owner": "charmbracelet",
         "repo": "nur",
-        "rev": "46e90ed9569cbfa50bfc217da1d079ff224c9f4e",
+        "rev": "c16b1b21157c231152b382b372cdb857ca526434",
         "type": "github"
       },
       "original": {
@@ -236,11 +236,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782522538,
-        "narHash": "sha256-CvOaUvJ+mXlxU3m2cPWKcOAhtKETsPUYhq+Xa5ewBp4=",
+        "lastModified": 1782881387,
+        "narHash": "sha256-HvlS1KDGXDjd1bNzzPvH1mkDJATlDAfVYfTh//wJBEA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8d8a6cc50ddc60748791a14ee1163c865ec57635",
+        "rev": "d32537981c036473cf6990ae03176a5d84c43b29",
         "type": "github"
       },
       "original": {
@@ -410,11 +410,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1782175435,
-        "narHash": "sha256-EMzXKmnOtBQ2MnvpiNOm7E+kOMvdPrIKaeg52Tip2Uk=",
+        "lastModified": 1782821651,
+        "narHash": "sha256-D5jO0ME1lA9bDHnd5kVawBwItG/N4oZr3FlXmMzLec8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "89570f24e97e614aa34aa9ab1c927b6578a43775",
+        "rev": "e52c192be9d7b2c4bd4aed326c8731b35f8bb75c",
         "type": "github"
       },
       "original": {
@@ -426,11 +426,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1782467914,
-        "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
         "type": "github"
       },
       "original": {
@@ -446,11 +446,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1782637429,
-        "narHash": "sha256-6LlAl8QH0SQ2VpmlxsKr23i6DTN9ma4ltSqlu8sNWOs=",
+        "lastModified": 1782896975,
+        "narHash": "sha256-5s9YvA4OaRkJD1JC8jZXma6iWHUQIxRQremdwj6zlCE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4ad71fa230d0686b4a0d4818c9b201b05fd4a0e2",
+        "rev": "116eb16ddb86fcd25edbc7dca91f83a23515abb2",
         "type": "github"
       },
       "original": {
@@ -586,11 +586,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1782474302,
-        "narHash": "sha256-0iXayrLi70oD8mJfJRhTN6+z6Cv3n1vEerCdfEJGYvg=",
+        "lastModified": 1782746706,
+        "narHash": "sha256-DHXYWlb8QSqpJ/xowIx15ynLaaO0B4np4DYIWsakY40=",
         "owner": "oraios",
         "repo": "serena",
-        "rev": "901bd2155a3b46cffb99b0a9416f1ccb65590c44",
+        "rev": "103a17072e9b915c9c9980f946902be856695978",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated update of `flake.lock` inputs.

All hosts built successfully against this lock file.
Merging will trigger `autodeploy.yaml`, which publishes store paths for pickup by `nixos-autodeploy`.

## Package changes

**Added: 0
0 | Removed: 0
0 | Changed: **

<details>
<summary>Full diff</summary>

```
acl: [31;1m125.2 KiB[0m
akonadi: [31;1m45.3 KiB[0m
alejandra: [32;1m-9.0 KiB[0m
alsa-lib: [31;1m1.8 MiB[0m
alsa-topology-conf: [31;1m336.1 KiB[0m
alsa-ucm-conf: [31;1m841.8 KiB[0m
at-spi2-core: ∅ → 2.60.4, [31;1m2.3 MiB[0m
attr: [31;1m90.5 KiB[0m
audit: ∅ → 4.1.4, [31;1m420.1 KiB[0m
aurorae: 6.7.0 → 6.7.1
avahi: [31;1m1.6 MiB[0m
baloo: [31;1m8.4 KiB[0m
bash: [31;1m1.8 MiB[0m
bind: 9.20.23 → 9.20.24
bluedevil: 6.7.0 → 6.7.1
bluez-qt: [31;1m8.5 KiB[0m
breeze-gtk: 6.7.0 → 6.7.1
breeze: 6.7.0, 6.7.0-qt5 → 6.7.1, 6.7.1-qt5, [31;1m25.5 KiB[0m
brotli: [31;1m961.9 KiB[0m
bzip2: [31;1m86.9 KiB[0m
cairo: [31;1m2.1 MiB[0m
coreutils: [31;1m1.7 MiB[0m
cracklib: [31;1m803.0 KiB[0m
crush: 0.80.0 → 0.81.0, [31;1m1.4 MiB[0m
cryptsetup: [31;1m2.7 MiB[0m
cups: [31;1m4.7 MiB[0m
curl: [31;1m1.2 MiB[0m
db: [31;1m7.7 MiB[0m
dbus: [31;1m461.6 KiB[0m
dconf: [31;1m324.5 KiB[0m
dejavu-fonts-minimal: [31;1m742.6 KiB[0m
discord: 1.0.143 → 1.0.144, [31;1m1.6 MiB[0m
discover: 6.7.0 → 6.7.1, [31;1m12.9 KiB[0m
docker-compose: 5.1.4 → 5.2.0, [32;1m-376.1 KiB[0m
docker-containerd: 29.5.3 → 29.6.0
docker-runc: 29.5.3 → 29.6.0, [31;1m8.5 KiB[0m
docker-tini: 29.5.3 → 29.6.0
docker: 29.5.3 → 29.6.0, [31;1m303.5 KiB[0m
doggo: 1.1.7 → 1.2.0, [31;1m8.0 KiB[0m
drkonqi: 6.7.0 → 6.7.1
e2fsprogs: 1.47.3 → 1.47.4
elfutils: [31;1m4.0 MiB[0m
elisa: [31;1m50.0 KiB[0m
expat: ∅ → 2.8.1, [31;1m308.4 KiB[0m
ffmpeg-headless: 8.1 → 8.1.1
ffmpeg: 8.1 → 8.1.1
fftw-double: 3.3.10 → 3.3.11
fftw-single: 3.3.10 → 3.3.11
firefox-unwrapped: 152.0.1 → 152.0.4, [31;1m418.7 KiB[0m
firefox: 152.0.1 → 152.0.4
fontconfig: [31;1m1.6 MiB[0m
freetype: ∅ → 2.14.3, [31;1m2.2 MiB[0m
fribidi: [31;1m162.5 KiB[0m
gcc: [32;1m-254.1 MiB[0m
gdk-pixbuf: [31;1m2.8 MiB[0m
getent-glibc: 2.42-61 → 2.42-67
ghostscript-with-X: 10.07.0 → 10.07.1, [31;1m37.6 KiB[0m
giflib: [31;1m407.5 KiB[0m
glib: [31;1m15.3 MiB[0m
glibc-locales: 2.42-61 → 2.42-67
glibc-multi: 2.42-61 → 2.42-67
glibc: ∅ → 2.42-67, [31;1m33.5 MiB[0m
gmp-with-cxx: [31;1m1.5 MiB[0m
gmp: 6.3.0 → ∅, [32;1m-722.5 KiB[0m
gnugrep: [31;1m932.4 KiB[0m
gnutls: [31;1m3.6 MiB[0m
go: 1.26.3 → 1.26.4, [32;1m-11.3 KiB[0m
gobject-introspection: [31;1m1.2 MiB[0m
graphite2: [31;1m228.0 KiB[0m
gsettings-desktop-schemas: [31;1m6.2 MiB[0m
gtk+3: [31;1m41.6 MiB[0m
harfbuzz: [31;1m3.7 MiB[0m
hwdata: [31;1m9.9 MiB[0m
hwdb.bin: [31;1m113.3 KiB[0m
icu4c: ∅ → 78.3, [31;1m77.8 MiB[0m
ijs: 10.07.0 → 10.07.1
imagemagick: 7.1.2-23 → 7.1.2-24, [31;1m8.4 KiB[0m
initrd-linux: 6.18.36 → 6.18.37, [32;1m-105.1 KiB[0m
initrd-linux: 6.18.36 → 6.18.37, [32;1m-108.0 KiB[0m
initrd-linux: 6.18.36 → 6.18.37, [32;1m-114.1 KiB[0m
iproute2: [31;1m4.6 MiB[0m
iptables: [31;1m2.2 MiB[0m
isl: 0.20 → ∅, [32;1m-2.5 MiB[0m
iso-codes: [31;1m22.6 MiB[0m
jjui: 0.10.6 → 0.10.7, [31;1m100.1 KiB[0m
json-c: [31;1m244.8 KiB[0m
json-glib: [31;1m662.9 KiB[0m
just: 1.53.0 → 1.54.0, [31;1m137.4 KiB[0m
kactivitymanagerd: 6.7.0 → 6.7.1
kate: [31;1m8.3 KiB[0m
kbd: [31;1m2.7 MiB[0m
kde-cli-tools: 6.7.0 → 6.7.1
kde-gtk-config: 6.7.0 → 6.7.1
kdecoration: 6.7.0 → 6.7.1
kdepim-runtime: [31;1m29.5 KiB[0m
kdeplasma-addons: 6.7.0 → 6.7.1, [31;1m17.2 KiB[0m
kexec-tools: [31;1m262.5 KiB[0m
keyutils: [31;1m41.8 KiB[0m
kglobalacceld: 6.7.0 → 6.7.1
kimap: [31;1m12.5 KiB[0m
kinfocenter: 6.7.0 → 6.7.1
kio: [31;1m35.3 KiB[0m
kmenuedit: 6.7.0 → 6.7.1
kmod: [31;1m325.6 KiB[0m
knighttime: 6.7.0 → 6.7.1
kpipewire: 6.7.0 → 6.7.1
krb5: ∅ → 1.22.2, [31;1m2.7 MiB[0m
krdp: 6.7.0 → 6.7.1
kscreen: 6.7.0 → 6.7.1
kscreenlocker: 6.7.0 → 6.7.1
ksshaskpass: 6.7.0 → 6.7.1
ksystemstats: 6.7.0 → 6.7.1
ktextaddons: 2.0.2 → 2.1.0, [31;1m3.2 MiB[0m
kwallet-pam: 6.7.0 → 6.7.1
kwallet: [31;1m14.1 KiB[0m
kwayland-integration: 6.7.0 → 6.7.1
kwayland: 6.7.0 → 6.7.1
kwin-x11: 6.7.0 → 6.7.1, [31;1m478.5 KiB[0m
kwin: 6.7.0 → 6.7.1, [31;1m330.3 KiB[0m
kwrited: 6.7.0 → 6.7.1
layer-shell-qt: 6.7.0 → 6.7.1
lerc: [31;1m842.4 KiB[0m
libadwaita: 1.9.0 → 1.9.1
libapparmor: [31;1m590.5 KiB[0m
libappindicator-gtk3: [31;1m89.7 KiB[0m
libarchive: [31;1m949.8 KiB[0m
libbpf: [31;1m2.1 MiB[0m
libcap-ng: [31;1m166.7 KiB[0m
libcbor: [31;1m83.6 KiB[0m
libcupsfilters: [31;1m450.3 KiB[0m
libdaemon: [31;1m41.0 KiB[0m
libdatrie: [31;1m42.2 KiB[0m
libdbusmenu-gtk3: [31;1m632.5 KiB[0m
libde265: 1.0.18 → 1.1.1, [31;1m73.9 KiB[0m
libdeflate: [31;1m458.6 KiB[0m
libdrm: [31;1m1.8 MiB[0m
libepoxy: [31;1m1.7 MiB[0m
libevent: [31;1m861.7 KiB[0m
libffi: [31;1m72.1 KiB[0m
libfido2: [31;1m1.1 MiB[0m
libgcrypt: ∅ → 1.12.2, [31;1m1.8 MiB[0m
libgcrypt: ∅ → 1.12.2, [31;1m1.9 MiB[0m
libglvnd: [31;1m2.5 MiB[0m
libgpg-error: [31;1m885.0 KiB[0m
libheif: 1.21.2 → 1.23.0, [31;1m300.9 KiB[0m
libidn2: [31;1m359.5 KiB[0m
libjpeg-turbo: [31;1m2.0 MiB[0m
libkscreen: 6.7.0 → 6.7.1, [31;1m17.5 KiB[0m
libksysguard: 6.7.0 → 6.7.1, [31;1m8.5 KiB[0m
libmicrohttpd: [31;1m260.4 KiB[0m
libmnl: [31;1m33.1 KiB[0m
libmpc: 1.4.0 → ∅, [32;1m-301.5 KiB[0m
libnetfilter_conntrack: [31;1m203.4 KiB[0m
libnfnetlink: [31;1m56.9 KiB[0m
libnotify: [31;1m111.2 KiB[0m
libpciaccess: [31;1m172.0 KiB[0m
libplasma: 6.7.0 → 6.7.1, [32;1m-10.7 KiB[0m
libpng-apng: ∅ → 1.6.58, [31;1m273.3 KiB[0m
libpsl: [31;1m114.9 KiB[0m
libpwquality: [31;1m382.5 KiB[0m
libseccomp: [31;1m193.8 KiB[0m
libselinux: [31;1m690.2 KiB[0m
libsoup: [31;1m1.2 MiB[0m
libssh2: [31;1m326.6 KiB[0m
libtasn1: [31;1m95.8 KiB[0m
libthai: [31;1m637.0 KiB[0m
libtiff: [31;1m739.2 KiB[0m
libtpms: [31;1m1.1 MiB[0m
libunistring: [31;1m2.0 MiB[0m
libvlc: [32;1m-1.1 MiB[0m
libwebp: [31;1m1.7 MiB[0m
libx11: [31;1m2.6 MiB[0m
libxau: [31;1m27.1 KiB[0m
libxcb: [31;1m1.4 MiB[0m
libxcomposite: [31;1m25.1 KiB[0m
libxcrypt: [31;1m141.0 KiB[0m
libxcursor: [31;1m77.9 KiB[0m
libxdamage: [31;1m17.9 KiB[0m
libxdmcp: [31;1m31.2 KiB[0m
libxext: [31;1m93.7 KiB[0m
libxfixes: [31;1m33.9 KiB[0m
libxft: [31;1m151.0 KiB[0m
libxi: [31;1m87.7 KiB[0m
libxinerama: [31;1m21.7 KiB[0m
libxkbcommon: [31;1m1.0 MiB[0m
libxml2: ∅ → 2.15.3, [31;1m1.4 MiB[0m
libxrandr: [31;1m62.6 KiB[0m
libxrender: [31;1m53.2 KiB[0m
libxtst: [31;1m117.6 KiB[0m
linux-firmware: 20260519 → 20260622, [31;1m17.0 MiB[0m
linux-pam: [31;1m1.8 MiB[0m
linux: 6.18.36 → 6.18.37, [31;1m22.8 KiB[0m
lvm2: [31;1m443.7 KiB[0m
lz4: [31;1m256.0 KiB[0m
lzo: [31;1m159.7 KiB[0m
mariadb-server: 11.4.9 → 11.4.12, [32;1m-116.7 KiB[0m
mdadm: 4.4 → 4.6, [31;1m13.8 KiB[0m
mesa-libgbm: [31;1m58.2 KiB[0m
milou: 6.7.0 → 6.7.1
mise: 2026.6.11 → 2026.6.13, [31;1m1.0 MiB[0m
moby: 29.5.3 → 29.6.0, [31;1m1.5 MiB[0m
modemmanager-qt: [31;1m16.1 KiB[0m
mpfr: [32;1m-803.3 KiB[0m
nano: 9.0 → 9.1, [31;1m24.0 KiB[0m
nettle: [31;1m723.5 KiB[0m
networkmanager-qt: [31;1m21.5 KiB[0m
nghttp2: [31;1m225.3 KiB[0m
nghttp3: [31;1m227.7 KiB[0m
ngtcp2: [31;1m484.3 KiB[0m
nixos-manual: [31;1m104.5 KiB[0m
nixos-system-kushtaka: 26.11.20260623.89570f2 → 26.11.20260630.e52c192
nixos-system-snallygaster: 26.11.20260623.89570f2 → 26.11.20260630.e52c192
nixos-system-wendigo: 26.11.20260623.89570f2 → 26.11.20260630.e52c192
nodejs-slim: 24.15.0 → 24.16.0, [31;1m1.3 MiB[0m
nodejs: 24.15.0 → 24.16.0, [31;1m46.9 KiB[0m
nspr: [31;1m349.8 KiB[0m
nss: [31;1m4.0 MiB[0m
ocean-sound-theme: 6.7.0 → 6.7.1
okular: [31;1m21.9 KiB[0m
onnxruntime: [31;1m1.6 MiB[0m
openapv: 0.2.1.2 → 0.2.1.3
openblas: 0.3.32 → 0.3.33
openexr: 3.4.10 → 3.4.11
openssl: [31;1m8.9 MiB[0m
openvino: ∅ → 2026.2.1, [31;1m131.6 MiB[0m
p11-kit: [31;1m5.7 MiB[0m
pango: [31;1m917.4 KiB[0m
pcre2: [31;1m2.0 MiB[0m
pcsclite: [31;1m107.3 KiB[0m
perl5.42.0-HTTP-Daemon: 6.16 → 6.17
perl: [31;1m32.5 KiB[0m
pimcommon: [31;1m8.7 KiB[0m
pixman: [31;1m858.3 KiB[0m
plasma-activities-stats: 6.7.0 → 6.7.1
plasma-activities: 6.7.0 → 6.7.1
plasma-browser-integration: 6.7.0 → 6.7.1
plasma-desktop: 6.7.0 → 6.7.1, [31;1m16.0 KiB[0m
plasma-integration: 6.7.0, 6.7.0-qt5 → 6.7.1, 6.7.1-qt5
plasma-keyboard: 6.7.0 → 6.7.1, [31;1m25.0 KiB[0m
plasma-nano: 6.7.0 → 6.7.1
plasma-nm: 6.7.0 → 6.7.1, [31;1m62.4 KiB[0m
plasma-pa: 6.7.0 → 6.7.1
plasma-sdk: 6.7.0 → 6.7.1
plasma-systemmonitor: 6.7.0 → 6.7.1, [31;1m11.0 KiB[0m
plasma-workspace-wallpapers: 6.7.0 → 6.7.1
plasma-workspace: 6.7.0 → 6.7.1, [31;1m41.0 KiB[0m
plasma5support: 6.7.0 → 6.7.1, [31;1m23.8 KiB[0m
polkit-kde-agent: 1-6.7.0 → 1-6.7.1
powerdevil: 6.7.0 → 6.7.1
print-manager: 6.7.0 → 6.7.1
prismlauncher-unwrapped: [31;1m26.5 KiB[0m
publicsuffix-list: ∅ → 0-unstable-2026-05-13, [31;1m331.4 KiB[0m
pulseaudio-qt: [31;1m8.2 KiB[0m
pydantic-settings: 2.13.1 → 2.14.2, [31;1m21.9 KiB[0m
pyright-internal: 1.1.410 → 1.1.411, [32;1m-10.1 MiB[0m
pyright: 1.1.410 → 1.1.411, [31;1m267.7 KiB[0m
python3.13-xmltodict: 1.0.2 → 1.0.4
qqc2-breeze-style: 6.7.0 → 6.7.1
qrencode: [31;1m62.6 KiB[0m
qt5compat: 6.11.0 → 6.11.1, [31;1m18.4 KiB[0m
qtbase: 5.15.18, 6.11.0, 6.11.0-only-plugins → 5.15.19, 6.11.1, 6.11.1-only-plugins, [31;1m245.1 KiB[0m
qtdeclarative: 5.15.18, 6.11.0 → 5.15.19, 6.11.1, [31;1m420.8 KiB[0m
qtgraphicaleffects: 5.15.18 → 5.15.19
qtimageformats: 6.11.0 → 6.11.1
qtlocation: 6.11.0 → 6.11.1, [31;1m13.1 KiB[0m
qtmultimedia: 6.11.0 → 6.11.1, [31;1m120.3 KiB[0m
qtnetworkauth: 6.11.0 → 6.11.1, [31;1m10.9 KiB[0m
qtpositioning: 6.11.0 → 6.11.1
qtquick3d: 6.11.0 → 6.11.1, [31;1m38.1 KiB[0m
qtquickcontrols2: 5.15.18 → 5.15.19
qtquickcontrols: 5.15.18 → 5.15.19
qtsensors: 6.11.0 → 6.11.1
qtserialport: 6.11.0 → 6.11.1
qtshadertools: 6.11.0 → 6.11.1
qtspeech: 6.11.0 → 6.11.1
qtsvg: 5.15.18, 6.11.0 → 5.15.19, 6.11.1
qttools: 5.15.18, 6.11.0 → 5.15.19, 6.11.1, [31;1m66.3 KiB[0m
qttranslations: 5.15.18, 6.11.0 → 5.15.19, 6.11.1, [31;1m50.3 KiB[0m
qtvirtualkeyboard: 6.11.0 → 6.11.1, [31;1m13.1 KiB[0m
qtwayland: 5.15.18, 6.11.0 → 5.15.19, 6.11.1, [31;1m105.0 KiB[0m
qtwebchannel: 6.11.0 → 6.11.1
qtwebengine: 6.11.0 → 6.11.1, [31;1m149.4 KiB[0m
qtwebsockets: 6.11.0 → 6.11.1
qtwebview: 6.11.0 → 6.11.1
qtx11extras: 5.15.18 → 5.15.19
rpcbind: 1.2.6 → 1.2.9
rsync: 3.4.1 → 3.4.4, [31;1m20.5 KiB[0m
ruff: 0.15.17 → 0.15.20, [31;1m556.5 KiB[0m
sd-switch: 0.6.3 → 0.6.4, [31;1m49.9 KiB[0m
sd: [32;1m-1.1 MiB[0m
sddm-unwrapped: [31;1m16.5 KiB[0m
sdl3: 3.4.8 → 3.4.10, [31;1m48.7 KiB[0m
serena-agent: [31;1m134.1 KiB[0m
signond: [31;1m23.3 KiB[0m
simdjson: 4.6.0 → 4.6.4, [31;1m24.1 KiB[0m
solid: [31;1m26.3 KiB[0m
source: [31;1m1.6 MiB[0m
spectacle: 6.7.0 → 6.7.1
sqlite: [31;1m5.6 MiB[0m
system: [31;1m11.1 KiB[0m
systemd-minimal-libs: ∅ → 260.2, [31;1m4.1 MiB[0m
systemd-minimal: ∅ → 260.2, [31;1m20.2 MiB[0m
systemd: ∅ → 260.2, [31;1m60.2 MiB[0m
systemd: ∅ → 260.2, [31;1m60.5 MiB[0m
systemsettings: 6.7.0 → 6.7.1
tinysparql: [31;1m4.7 MiB[0m
tmux: 3.6a → 3.7, [31;1m101.1 KiB[0m
tpm2-tss: [31;1m3.2 MiB[0m
unbound: ∅ → 1.25.1, [31;1m1.1 MiB[0m
union: 6.7.0 → 6.7.1
util-linux-minimal: [31;1m2.4 MiB[0m
vimplugin-ale: 4.0.0-unstable-2026-06-01 → 4.0.0-unstable-2026-06-21, [31;1m34.6 KiB[0m
vimplugin-nvim-tree.lua: 1.17.0-unstable-2026-06-15 → 1.17.0-unstable-2026-06-20
vlc: [32;1m-1.1 MiB[0m
wayland: [31;1m264.1 KiB[0m
x86_energy_perf_policy: 6.18.36 → 6.18.37
xdg-desktop-portal-kde: 6.7.0 → 6.7.1, [31;1m14.1 KiB[0m
xgcc: [31;1m193.0 KiB[0m
xh: 0.25.3 → 0.26.1, [31;1m2.2 MiB[0m
xkeyboard-config: [31;1m10.3 MiB[0m
xz: [31;1m837.8 KiB[0m
zlib: [31;1m278.8 KiB[0m
zstd: [31;1m1.1 MiB[0m
```

</details>