### PR TITLE
chore: update claude-code

### DIFF
--- a/pkgs/claude-code/default.nix
+++ b/pkgs/claude-code/default.nix
@@ -11,7 +11,7 @@
   callPackage,
   binName ? "claude",
 }: let
-  version = "2.1.196";
+  version = "2.1.198";
 
   platformMap = {
     "aarch64-darwin" = "darwin-arm64";
@@ -25,10 +25,10 @@
       or (throw "claude-code: unsupported platform ${stdenv.hostPlatform.system}");
 
   nativeHashes = {
-    "darwin-arm64" = "0nhg0wq3mpfyr6gmif8c71livsbrkw6zjpr287r2nb2qnwdfdikg";
-    "darwin-x64" = "1q0ydn4shp86h6lv556js05lg40wn5nc93v3x9xag73vw9k4virj";
-    "linux-x64" = "1pmsgg1ywdxs6h7vpqzpjl9vsch9bjfh02dshfdvhkaksmnkr4zb";
-    "linux-arm64" = "1n2dznkbvrbc8l26gxdgb4ancghrk7baq24nr8hykl9msf4r3ah5";
+    "darwin-arm64" = "07nna5j2cr4sc0jz82d679i5p01zcd358a3w9x0xwvl117hpwvxb";
+    "darwin-x64" = "1l1dr02j9h2475in0vjmb4bw0nf2afg29w8ssfp4rk6sc3y6q2r8";
+    "linux-x64" = "0kdqnsa6piwjv3yj3c9c14l3kp1lq3a74l5g2f6074zylm1ayrkh";
+    "linux-arm64" = "16if6whamcbj34rgm2j29v471i43k0pqmrgir9xz0ghz5dphmdcr";
   };
 
   nativeBinary = fetchurl {


### PR DESCRIPTION
Automated update of `pkgs/claude-code` to the latest version published on npm.

The new binary has been built and pushed to Cachix — no local build required after merge.