### PR TITLE
Add Proton-GE to gaming profile

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -85,10 +85,13 @@
       # TEMP: pin mullvad-vpn to 2026.2 — 2026.3 fails to build upstream.
       # See the nixpkgs-mullvad input above. Remove with that input.
       (final: _prev: {
-        inherit ((import inputs.nixpkgs-mullvad {
+        inherit
+          ((import inputs.nixpkgs-mullvad {
             inherit (final.stdenv.hostPlatform) system;
             config.allowUnfree = true;
-          })) mullvad-vpn;
+          }))
+          mullvad-vpn
+          ;
       })
     ];
 

--- a/nixos/profiles/gaming.nix
+++ b/nixos/profiles/gaming.nix
@@ -1,11 +1,13 @@
 # nixos/profiles/gaming.nix
-_: {
+{pkgs, ...}: {
   programs.steam = {
     enable = true;
 
     remotePlay.openFirewall = true;
     dedicatedServer.openFirewall = true;
     localNetworkGameTransfers.openFirewall = false;
+
+    extraCompatPackages = [pkgs.proton-ge-bin];
   };
 
   programs.gamemode.enable = true;


### PR DESCRIPTION
This pull request introduces an improvement to the gaming profile and a minor formatting fix in the Nix flake configuration. The most important changes are:

**Gaming profile enhancements:**

* Added `pkgs.proton-ge-bin` to the `extraCompatPackages` for Steam in `nixos/profiles/gaming.nix`, providing users with an additional compatibility tool for running Windows games on Linux.

**Nix flake formatting:**

* Reformatted the override for `mullvad-vpn` in `flake.nix` for improved clarity and maintainability; no functional changes were made.