### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -56,11 +56,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1782822334,
-        "narHash": "sha256-dNh489qzsUf2QvliQk5jnc9+fdIyPJs2185/vNSShKg=",
+        "lastModified": 1783647577,
+        "narHash": "sha256-A5gUnF//pY6DvR2sqNAJEynz8DyGIX+syqZeiC5ogkM=",
         "owner": "charmbracelet",
         "repo": "nur",
-        "rev": "c16b1b21157c231152b382b372cdb857ca526434",
+        "rev": "dc85c5c51f4bf18721bfba5e71004d2dcd22e1cd",
         "type": "github"
       },
       "original": {
@@ -236,11 +236,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782881387,
-        "narHash": "sha256-HvlS1KDGXDjd1bNzzPvH1mkDJATlDAfVYfTh//wJBEA=",
+        "lastModified": 1783618078,
+        "narHash": "sha256-F43DGcBoIO8xOZFAfodg3jy0VghB9NGdb6xbTYAIx1A=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d32537981c036473cf6990ae03176a5d84c43b29",
+        "rev": "144f4e36d0186195037da9fce80a727108978070",
         "type": "github"
       },
       "original": {
@@ -275,11 +275,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782636943,
-        "narHash": "sha256-ripjZa7BBLwL1uS5VJF3s/VpZpWt5ZIQEvkJ/FJNpQw=",
+        "lastModified": 1783414108,
+        "narHash": "sha256-RY8e+gR2/DhXsYDxGDL6Hhe9+POD9u4+llwxMBqMQDs=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "058b1f9381fa79fcda49982370a750ff92dbba43",
+        "rev": "96d6de10eb281b98f5cfcd1841394c03da5df77c",
         "type": "github"
       },
       "original": {
@@ -317,11 +317,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1782562157,
-        "narHash": "sha256-a7+T6QSeowynwZ1ZJJbP8T8ntAytvrui8kFGJmIZt2c=",
+        "lastModified": 1783673680,
+        "narHash": "sha256-ardRVG+ipnyyxVdIsbLMy5foO6gDqN/yIi8v10HTJqs=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "a9cf7546a938c737b079e738de73934a13de9784",
+        "rev": "0b655af52b5b89bcceb88737efdc3a7498e751ee",
         "type": "github"
       },
       "original": {
@@ -410,11 +410,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1782821651,
-        "narHash": "sha256-D5jO0ME1lA9bDHnd5kVawBwItG/N4oZr3FlXmMzLec8=",
+        "lastModified": 1783279667,
+        "narHash": "sha256-/NAkDSsve+GNM0Bt6tleJdCGfsTlK89nPjkVOzZMo0s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e52c192be9d7b2c4bd4aed326c8731b35f8bb75c",
+        "rev": "f205b5574fd0cb7da5b702a2da51507b7f4fdd1b",
         "type": "github"
       },
       "original": {
@@ -426,11 +426,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "lastModified": 1783522502,
+        "narHash": "sha256-iffAls3iaNTyJC2faYcUXSI+Gp02cDjYl+MygxKl2GI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "rev": "0bb7ec54c8483066ec9d7720e780a5caa71f8612",
         "type": "github"
       },
       "original": {
@@ -446,11 +446,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1782896975,
-        "narHash": "sha256-5s9YvA4OaRkJD1JC8jZXma6iWHUQIxRQremdwj6zlCE=",
+        "lastModified": 1783680628,
+        "narHash": "sha256-IpMvSBiDqoz3lHQZxRXZouMRos8ZY/e06vegE/eS4io=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "116eb16ddb86fcd25edbc7dca91f83a23515abb2",
+        "rev": "c978e0ef4fd585c1d8bbc46bbd0d207e1249ab0b",
         "type": "github"
       },
       "original": {
@@ -586,11 +586,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1782746706,
-        "narHash": "sha256-DHXYWlb8QSqpJ/xowIx15ynLaaO0B4np4DYIWsakY40=",
+        "lastModified": 1783420168,
+        "narHash": "sha256-t9gJEgRaFEK6Dsw61sILcfRZ9byhKwzxbnNRb9LH8mU=",
         "owner": "oraios",
         "repo": "serena",
-        "rev": "103a17072e9b915c9c9980f946902be856695978",
+        "rev": "e08e964d0c8703401f7ad419b9bf69d85d35188d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated update of `flake.lock` inputs.

All hosts built successfully against this lock file.
Merging will trigger `autodeploy.yaml`, which publishes store paths for pickup by `nixos-autodeploy`.

## Package changes

**Added: 1 | Removed: 0
0 | Changed: **

<details>
<summary>Full diff</summary>

```
1password: 8.12.24 → 8.12.26, [31;1m12.1 MiB[0m
akonadi-calendar: 26.04.2 → 26.04.3
akonadi-contacts: 26.04.2 → 26.04.3
akonadi-mime: 26.04.2 → 26.04.3
akonadi-search: 26.04.2 → 26.04.3
akonadi: 26.04.2 → 26.04.3
ark: 26.04.2 → 26.04.3
aurorae: 6.7.1 → 6.7.2
baloo-widgets: 26.04.2 → 26.04.3
bluedevil: 6.7.1 → 6.7.2
breeze-gtk: 6.7.1 → 6.7.2
breeze: 6.7.1, 6.7.1-qt5 → 6.7.2, 6.7.2-qt5
crush: 0.81.0 → 0.84.0, [32;1m-40.0 KiB[0m
delve: 1.26.3 → 1.27.0, [32;1m-239.5 KiB[0m
discover: 6.7.1 → 6.7.2
docker-compose: 5.2.0 → 5.3.0, [31;1m28.1 KiB[0m
docker-containerd: 29.6.0 → 29.6.1, [31;1m28.3 KiB[0m
docker-runc: 29.6.0 → 29.6.1
docker-tini: 29.6.0 → 29.6.1
docker: 29.6.0 → 29.6.1
dolphin-plugins: 26.04.2 → 26.04.3
dolphin: 26.04.2 → 26.04.3
drkonqi: 6.7.1 → 6.7.2
electron-unwrapped: 40.10.3, 41.7.2, 42.4.0 → 41.9.1, 42.5.1, [32;1m-300.2 MiB[0m
electron: 40.10.3, 41.7.2, 42.4.0 → 41.9.1, 42.5.1
elisa: 26.04.2 → 26.04.3
ffmpegthumbs: 26.04.2 → 26.04.3
firefox-unwrapped: [31;1m97.7 KiB[0m
gh-dash: 4.24.1 → 4.25.0, [31;1m928.5 KiB[0m
gh: 2.95.0 → 2.96.0, [31;1m20.5 KiB[0m
grantleetheme: 26.04.2 → 26.04.3
gwenview: 26.04.2 → 26.04.3
home-configuration-reference: [31;1m17.4 KiB[0m
index-x86_64-linux: [31;1m421.8 KiB[0m
index-x86_64: [31;1m37.8 MiB[0m
initrd-linux: 6.18.37 → 6.18.38, [32;1m-39.6 KiB[0m
initrd-linux: 6.18.37 → 6.18.38, [32;1m-46.1 KiB[0m
initrd-linux: 6.18.37 → 6.18.38, [32;1m-47.5 KiB[0m
jjui: 0.10.7 → 0.10.8, [31;1m21.9 KiB[0m
jujutsu: 0.42.0 → 0.43.0, [31;1m219.3 KiB[0m
just: 1.54.0 → 1.55.1, [31;1m68.9 KiB[0m
kaccounts-integration: 26.04.2 → 26.04.3
kactivitymanagerd: 6.7.1 → 6.7.2
kate: 26.04.2 → 26.04.3, [32;1m-454.4 KiB[0m
kcalutils: 26.04.2 → 26.04.3
kde-cli-tools: 6.7.1 → 6.7.2
kde-gtk-config: 6.7.1 → 6.7.2
kde-inotify-survey: 26.04.2 → 26.04.3
kdecoration: 6.7.1 → 6.7.2
kdegraphics-mobipocket: 26.04.2 → 26.04.3
kdegraphics-thumbnailers: 26.04.2 → 26.04.3
kdepim-runtime: 26.04.2 → 26.04.3
kdeplasma-addons: 6.7.1 → 6.7.2
kglobalacceld: 6.7.1 → 6.7.2
khelpcenter: 26.04.2 → 26.04.3
kidentitymanagement: 26.04.2 → 26.04.3
kimap: 26.04.2 → 26.04.3
kinfocenter: 6.7.1 → 6.7.2
kio-admin: 26.04.2 → 26.04.3
kio-extras: 26.04.2 → 26.04.3
kitty-themes: 0-unstable-2026-06-08 → 0-unstable-2026-06-29
kldap: 26.04.2 → 26.04.3
kmailtransport: 26.04.2 → 26.04.3
kmbox: 26.04.2 → 26.04.3
kmenuedit: 6.7.1 → 6.7.2
kmime: 26.04.2 → 26.04.3
knighttime: 6.7.1 → 6.7.2
konsole: 26.04.2 → 26.04.3
kpimtextedit: 26.04.2 → 26.04.3
kpipewire: 6.7.1 → 6.7.2
krdp: 6.7.1 → 6.7.2
kscreen: 6.7.1 → 6.7.2
kscreenlocker: 6.7.1 → 6.7.2
ksmtp: 26.04.2 → 26.04.3
ksshaskpass: 6.7.1 → 6.7.2
ksystemstats: 6.7.1 → 6.7.2
kunifiedpush: 26.04.2 → 26.04.3
kwallet-pam: 6.7.1 → 6.7.2
kwalletmanager: 26.04.2 → 26.04.3
kwayland-integration: 6.7.1 → 6.7.2
kwayland: 6.7.1 → 6.7.2
kwin-x11: 6.7.1 → 6.7.2
kwin: 6.7.1 → 6.7.2, [31;1m30.5 KiB[0m
kwrited: 6.7.1 → 6.7.2
layer-shell-qt: 6.7.1 → 6.7.2
libgravatar: 26.04.2 → 26.04.3
libkdcraw: 26.04.2 → 26.04.3
libkdepim: 26.04.2 → 26.04.3
libkexiv2: 26.04.2 → 26.04.3
libkgapi: 26.04.2 → 26.04.3
libkleo: 26.04.2 → 26.04.3
libkscreen: 6.7.1 → 6.7.2
libksysguard: 6.7.1 → 6.7.2
libplasma: 6.7.1 → 6.7.2
linux: 6.18.37 → 6.18.38, [31;1m67.5 KiB[0m
mesa: 26.1.3 → 26.1.4, [31;1m377.9 KiB[0m
mesa: 26.1.3 → 26.1.4, [31;1m745.8 KiB[0m
messagelib: 26.04.2 → 26.04.3
milou: 6.7.1 → 6.7.2
mise: 2026.6.13 → 2026.7.0, [32;1m-548.4 KiB[0m
moby: 29.6.0 → 29.6.1, [31;1m34.0 KiB[0m
nh-unwrapped: 4.3.2 → 4.4.0, [31;1m1.0 MiB[0m
nh: 4.3.2 → 4.4.0
nixos-manual: [31;1m128.8 KiB[0m
nixos-system-kushtaka: 26.11.20260630.e52c192 → 26.11.20260705.f205b55
nixos-system-snallygaster: 26.11.20260630.e52c192 → 26.11.20260705.f205b55
nixos-system-wendigo: 26.11.20260630.e52c192 → 26.11.20260705.f205b55
noto-fonts: 2026.06.01 → 2026.07.01
ocean-sound-theme: 6.7.1 → 6.7.2
okular: 26.04.2 → 26.04.3
openvpn: 2.6.19 → 2.6.21
pimcommon: 26.04.2 → 26.04.3
pipewire-extra: ε → ∅
plasma-activities-stats: 6.7.1 → 6.7.2
plasma-activities: 6.7.1 → 6.7.2
plasma-browser-integration: 6.7.1 → 6.7.2
plasma-desktop: 6.7.1 → 6.7.2, [31;1m15.6 KiB[0m
plasma-integration: 6.7.1, 6.7.1-qt5 → 6.7.2, 6.7.2-qt5
plasma-keyboard: 6.7.1 → 6.7.2
plasma-nano: 6.7.1 → 6.7.2
plasma-nm: 6.7.1 → 6.7.2
plasma-pa: 6.7.1 → 6.7.2
plasma-sdk: 6.7.1 → 6.7.2, [31;1m8.6 KiB[0m
plasma-systemmonitor: 6.7.1 → 6.7.2
plasma-workspace-wallpapers: 6.7.1 → 6.7.2
plasma-workspace: 6.7.1 → 6.7.2, [31;1m22.6 KiB[0m
plasma5support: 6.7.1 → 6.7.2
polkit-kde-agent: 1-6.7.1 → 1-6.7.2
powerdevil: 6.7.1 → 6.7.2
print-manager: 6.7.1 → 6.7.2
qqc2-breeze-style: 6.7.1 → 6.7.2
qrca: 26.04.2 → 26.04.3
revive: 1.11.0 → 1.15.0, [31;1m540.6 KiB[0m
serena-agent: [32;1m-16.9 KiB[0m
source: [31;1m481.4 KiB[0m
spectacle: 6.7.1 → 6.7.2
starship: 1.25.1 → 1.26.0, [31;1m340.8 KiB[0m
systemsettings: 6.7.1 → 6.7.2
tailscale: 1.98.5 → 1.98.8
tmux: 3.7 → 3.7b
unifont: 17.0.04 → 17.0.05
union: 6.7.1 → 6.7.2
usage: 3.5.0 → 3.5.3
x86_energy_perf_policy: 6.18.37 → 6.18.38
xdg-desktop-portal-kde: 6.7.1 → 6.7.2
zoxide: 0.9.9 → 0.10.0, [31;1m73.0 KiB[0m
```

</details>