### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -56,11 +56,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1783647577,
-        "narHash": "sha256-A5gUnF//pY6DvR2sqNAJEynz8DyGIX+syqZeiC5ogkM=",
+        "lastModified": 1783779223,
+        "narHash": "sha256-W4/tstArVC8ClhQA9GnaKtYk2H19d5r9AMVfxCCUkGE=",
         "owner": "charmbracelet",
         "repo": "nur",
-        "rev": "dc85c5c51f4bf18721bfba5e71004d2dcd22e1cd",
+        "rev": "54d99fa779339d6f2cb35ede4f5908fe88bcfe4e",
         "type": "github"
       },
       "original": {
@@ -236,11 +236,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783618078,
-        "narHash": "sha256-F43DGcBoIO8xOZFAfodg3jy0VghB9NGdb6xbTYAIx1A=",
+        "lastModified": 1783823409,
+        "narHash": "sha256-OI4IkRjRXa1e7hYmCGJDPDq5H/kPwhsyoS80cNUF9fI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "144f4e36d0186195037da9fce80a727108978070",
+        "rev": "7566825d4652a1b885bd4ce65bd9e8def432fec9",
         "type": "github"
       },
       "original": {
@@ -275,11 +275,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783414108,
-        "narHash": "sha256-RY8e+gR2/DhXsYDxGDL6Hhe9+POD9u4+llwxMBqMQDs=",
+        "lastModified": 1783864904,
+        "narHash": "sha256-BQxN5UMg9FOevAsgBRwPxfxlh51Puj+dNn/8Dsi3sPM=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "96d6de10eb281b98f5cfcd1841394c03da5df77c",
+        "rev": "1111b9bc836afb7e31a7014e8d1272de9b1c917d",
         "type": "github"
       },
       "original": {
@@ -317,11 +317,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1783673680,
-        "narHash": "sha256-ardRVG+ipnyyxVdIsbLMy5foO6gDqN/yIi8v10HTJqs=",
+        "lastModified": 1783792734,
+        "narHash": "sha256-50rvY9GdFvpYDcMLcD/4cWSi0hVxArT5wsGlVsHy8eY=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "0b655af52b5b89bcceb88737efdc3a7498e751ee",
+        "rev": "8efb4337e857949f4cfac86d12ef1066f417f31f",
         "type": "github"
       },
       "original": {
@@ -410,11 +410,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1783279667,
-        "narHash": "sha256-/NAkDSsve+GNM0Bt6tleJdCGfsTlK89nPjkVOzZMo0s=",
+        "lastModified": 1783816212,
+        "narHash": "sha256-2aZisVTVGSFEk3MYcOiWQp3zvwyzbqpktB69Rcfp150=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f205b5574fd0cb7da5b702a2da51507b7f4fdd1b",
+        "rev": "3b32825de172d0bc85664f495edb096b10862524",
         "type": "github"
       },
       "original": {
@@ -426,11 +426,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1783522502,
-        "narHash": "sha256-iffAls3iaNTyJC2faYcUXSI+Gp02cDjYl+MygxKl2GI=",
+        "lastModified": 1783776592,
+        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0bb7ec54c8483066ec9d7720e780a5caa71f8612",
+        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
         "type": "github"
       },
       "original": {
@@ -446,11 +446,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1783680628,
-        "narHash": "sha256-IpMvSBiDqoz3lHQZxRXZouMRos8ZY/e06vegE/eS4io=",
+        "lastModified": 1783940221,
+        "narHash": "sha256-1Ag6swAtj09kqxWOThwX9Wy2pfz5fiKpEq+9cjPfTZU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c978e0ef4fd585c1d8bbc46bbd0d207e1249ab0b",
+        "rev": "b17d7cdbfa8b70c6d5bf1360cfc95926cbd68327",
         "type": "github"
       },
       "original": {
@@ -586,11 +586,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1783420168,
-        "narHash": "sha256-t9gJEgRaFEK6Dsw61sILcfRZ9byhKwzxbnNRb9LH8mU=",
+        "lastModified": 1783855201,
+        "narHash": "sha256-VyouKfOJl4FwSTcW1hDLsq5/BX6+1BKUL+LG+wnKWYE=",
         "owner": "oraios",
         "repo": "serena",
-        "rev": "e08e964d0c8703401f7ad419b9bf69d85d35188d",
+        "rev": "9bbbfea8d62d130d06037cc0b283291bd20e79c3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated update of `flake.lock` inputs.

All hosts built successfully against this lock file.
Merging will trigger `autodeploy.yaml`, which publishes store paths for pickup by `nixos-autodeploy`.

## Package changes

**Added: 1 | Removed: 0
0 | Changed: **

<details>
<summary>Full diff</summary>

```
akonadi-search: [31;1m8.9 KiB[0m
akonadi: [32;1m-8.0 KiB[0m
alsa-lib: ∅ → 1.2.16
alsa-lib: ∅ → 1.2.16, [31;1m9.4 KiB[0m
alsa-ucm-conf: ∅ → 1.2.16, [31;1m143.3 KiB[0m
alsa-ucm-conf: ∅ → 1.2.16, [31;1m71.7 KiB[0m
appstream-qt: 1.1.2 → 1.1.3, [31;1m370.9 KiB[0m
appstream: 1.1.2 → 1.1.3, [31;1m370.9 KiB[0m
attica: 6.27.0 → 6.28.0
atuin: 18.16.1 → 18.17.0, [31;1m3.6 MiB[0m
aws-c-http: 0.10.4 → 0.11.0, [31;1m12.9 KiB[0m
aws-c-io: 0.22.0 → 0.27.2
baloo: 6.27.0 → 6.28.0
bcachefs-tools: ∅ → 1.38.8, [31;1m9.4 MiB[0m
blueman: [31;1m380.1 KiB[0m
bluez-qt: 6.27.0 → 6.28.0
breeze-icons: 6.27.0 → 6.28.0
comma: [32;1m-15.8 KiB[0m
crush: 0.84.0 → 0.84.1, [31;1m20.0 KiB[0m
curl: ∅ → 8.21.0, [31;1m66.7 KiB[0m
cxx-rust-cssparser: [32;1m-8.2 KiB[0m
dash: 0.5.13.3 → 0.5.13.4
ddcutil: [32;1m-12.0 KiB[0m
delta: [32;1m-12.0 KiB[0m
discord: 1.0.144 → 1.0.146, [31;1m471.4 KiB[0m
djvulibre: 3.5.29 → 3.5.30
docker-buildx: 0.31.1 → 0.35.0, [32;1m-24.1 MiB[0m
docker-compose: 5.3.0 → 5.3.1, [31;1m36.0 KiB[0m
double-conversion: 3.3.1 → 3.4.0
electron-unwrapped: [32;1m-50.7 KiB[0m
elfutils: ∅ → 0.195, [31;1m105.2 KiB[0m
elfutils: ∅ → 0.195, [31;1m61.2 KiB[0m
expat: 2.8.1 → 2.8.2, [31;1m129.7 KiB[0m
eza: 0.23.4 → 0.23.5, [31;1m436.7 KiB[0m
fc: [31;1m55.8 KiB[0m
ffmpeg-headless: 8.1.1 → 8.1.2, [31;1m12.6 KiB[0m
ffmpeg-headless: 8.1.1 → 8.1.2, [31;1m84.3 KiB[0m
ffmpeg: 8.1.1 → 8.1.2, [31;1m16.6 KiB[0m
file: 5.47 → 5.48, [31;1m274.0 KiB[0m
file: 5.47 → 5.48, [31;1m274.1 KiB[0m
firefox-unwrapped: 152.0.4 → 152.0.5, [31;1m242.0 KiB[0m
firefox: 152.0.4 → 152.0.5
fluidsynth: 2.5.3 → 2.5.5
fontconfig: ∅ → 2.18.1, [31;1m91.9 KiB[0m
frameworkintegration: 6.27.0 → 6.28.0
fuse: 3.17.4 → 3.18.2, [31;1m82.1 KiB[0m
fzf: 0.73.1 → 0.74.0, [31;1m74.3 KiB[0m
game-music-emu: 0.6.4 → 0.6.5
gdb-host-cpu-only: 17.1 → 17.2
giflib: ∅ → 6.1.3, [31;1m136.7 KiB[0m
glslang: 16.2.0 → 16.3.0, [31;1m213.7 KiB[0m
gnused: 4.9 → 4.10, [31;1m163.2 KiB[0m
gopls: 0.22.0 → 0.23.0, [32;1m-103.3 KiB[0m
gperftools: 2.17.2 → ∅, [32;1m-4.8 MiB[0m
gpgme: 2.0.1 → 2.1.0
gpgmepp: 2.0.0 → 2.1.0
graphite2: ∅ → 1.3.15
gssdp: 1.6.4 → 1.6.5
gst-plugins-bad: 1.26.11 → 1.28.4, [31;1m765.8 KiB[0m
gst-plugins-base: 1.26.11 → 1.28.4, [31;1m163.7 KiB[0m
gst-plugins-base: 1.26.11 → 1.28.4, [31;1m357.6 KiB[0m
gst-plugins-good: 1.26.11 → 1.28.4, [31;1m164.4 KiB[0m
gstreamer: 1.26.11 → 1.28.4, [31;1m187.4 KiB[0m
gstreamer: 1.26.11 → 1.28.4, [31;1m379.6 KiB[0m
gtest: [31;1m1.0 MiB[0m
gupnp: 1.6.9 → 1.6.10
hdrhistogram_c: ∅ → 0.11.9, [31;1m385.1 KiB[0m
hm_kittydiff.conf: ε → ∅
hunspell: 1.7.2 → 1.7.3, [31;1m22.0 KiB[0m
hwdata: ∅ → 0.408, [31;1m186.9 KiB[0m
hwdb.bin: [31;1m88.3 KiB[0m
hwloc: 2.13.0 → 2.14.0, [31;1m8.3 KiB[0m
ibus: 1.5.33 → 1.5.34, [31;1m237.7 KiB[0m
icu4c: 78.3 → ∅, [32;1m-39.6 MiB[0m
imagemagick: 7.1.2-24 → 7.1.2-27, [31;1m78.9 KiB[0m
index-x86_64-linux: [32;1m-40.3 KiB[0m
index-x86_64: [32;1m-2.6 MiB[0m
initrd-linux: [31;1m1.7 MiB[0m
intel-graphics-compiler: [32;1m-31.5 KiB[0m
iproute2: ∅ → 7.1.0
jq: 1.8.1 → 1.8.2, [31;1m32.5 KiB[0m
jujutsu: [32;1m-21.1 KiB[0m
just: [32;1m-18.4 KiB[0m
karchive: 6.27.0 → 6.28.0
kauth: 6.27.0 → 6.28.0
kbookmarks: 6.27.0 → 6.28.0
kcalendarcore: 6.27.0 → 6.28.0
kcmutils: 6.27.0 → 6.28.0
kcodecs: 6.27.0 → 6.28.0
kcolorscheme: 6.27.0 → 6.28.0
kcompletion: 6.27.0 → 6.28.0
kconfig: 6.27.0 → 6.28.0, [31;1m37.9 KiB[0m
kconfigwidgets: 6.27.0 → 6.28.0, [31;1m22.9 KiB[0m
kcontacts: 6.27.0 → 6.28.0
kcoreaddons: 6.27.0 → 6.28.0, [31;1m45.5 KiB[0m
kcrash: 6.27.0 → 6.28.0
kdav: 6.27.0 → 6.28.0
kdbusaddons: 6.27.0 → 6.28.0
kdeclarative: 6.27.0 → 6.28.0
kded: 6.27.0 → 6.28.0
kdeplasma-addons: [31;1m16.0 KiB[0m
kdesu: 6.27.0 → 6.28.0
kdnssd: 6.27.0 → 6.28.0
kdoctools: 6.27.0 → 6.28.0
kdsoap-ws-discovery-client: [32;1m-116.2 KiB[0m
kfilemetadata: 6.27.0 → 6.28.0, [32;1m-39.6 KiB[0m
kglobalaccel: 6.27.0 → 6.28.0
kguiaddons: 6.27.0 → 6.28.0
kholidays: 6.27.0 → 6.28.0, [31;1m10.4 KiB[0m
ki18n: 6.27.0 → 6.28.0
kiconthemes: 6.27.0 → 6.28.0
kidletime: 6.27.0 → 6.28.0
kimageformats: 6.27.0 → 6.28.0
kio: 6.27.0 → 6.28.0, [31;1m245.9 KiB[0m
kirigami: 6.27.0 → 6.28.0
kitemmodels: 6.27.0 → 6.28.0
kitemviews: 6.27.0 → 6.28.0
kitty: [31;1m1.7 MiB[0m
kjobwidgets: 6.27.0 → 6.28.0
knewstuff: 6.27.0 → 6.28.0
knotifications: 6.27.0 → 6.28.0
knotifyconfig: 6.27.0 → 6.28.0
kpackage: 6.27.0 → 6.28.0
kparts: 6.27.0 → 6.28.0
kpty: 6.27.0 → 6.28.0
kquickcharts: 6.27.0 → 6.28.0
krunner: 6.27.0 → 6.28.0
kservice: 6.27.0 → 6.28.0
kstatusnotifieritem: 6.27.0 → 6.28.0
ksvg: 6.27.0 → 6.28.0
ktexteditor: 6.27.0 → 6.28.0, [31;1m222.9 KiB[0m
ktexttemplate: 6.27.0 → 6.28.0
ktextwidgets: 6.27.0 → 6.28.0
kunitconversion: 6.27.0 → 6.28.0, [31;1m277.4 KiB[0m
kuserfeedback: 6.27.0 → 6.28.0
kwallet: 6.27.0 → 6.28.0
kwidgetsaddons: 6.27.0 → 6.28.0
kwindowsystem: 6.27.0 → 6.28.0, [31;1m26.0 KiB[0m
kxmlgui: 6.27.0 → 6.28.0, [31;1m86.4 KiB[0m
lcms2: 2.18 → 2.19.1
lcms2: 2.18 → 2.19.1, [31;1m9.0 KiB[0m
ldacBT: 2.0.2.3 → ∅, [32;1m-163.1 KiB[0m
ldacBT: 2.0.2.3 → ∅, [32;1m-88.7 KiB[0m
ldacbt: ∅ → 2.0.72, [31;1m183.6 KiB[0m
ldacbt: ∅ → 2.0.72, [31;1m98.7 KiB[0m
ldns: 1.9.0 → 1.9.2
lerc: [31;1m24.9 KiB[0m
less: 692 → 704, [31;1m11.7 KiB[0m
libapparmor: ∅ → 5.0.0, [31;1m18.4 KiB[0m
libarchive: ∅ → 3.8.8
libarchive: ∅ → 3.8.8, [31;1m11.4 KiB[0m
libavif: 1.4.1 → 1.4.2, [31;1m16.1 KiB[0m
libcap: 2.77 → 2.78
libcbor: ∅ → 0.14.0
libconfig: 1.8 → 1.8.2, [31;1m25.0 KiB[0m
libconfig: 1.8 → 1.8.2, [31;1m8.5 KiB[0m
libdovi: [32;1m-10.0 KiB[0m
libdrm: ∅ → 2.4.134, [31;1m104.6 KiB[0m
libdrm: ∅ → 2.4.134, [31;1m204.9 KiB[0m
libdvdcss: 1.4.3 → 1.5.0, [32;1m-36.8 KiB[0m
libdvdread: [32;1m-9.6 KiB[0m
libedit: 20251016-3.1 → 20260508-3.1
libei: 1.5.0 → 1.6.0, [31;1m32.5 KiB[0m
libgpg-error: ∅ → 1.61
libheif: 1.23.0 → 1.23.1, [31;1m12.7 KiB[0m
libidn: 1.43 → 1.44
libidn: 1.43 → 1.44, [31;1m9.5 KiB[0m
libjpeg-turbo: ∅ → 3.1.4.1
libjxl: [32;1m-3.2 MiB[0m
libksba: 1.6.7 → 1.8.0, [31;1m8.5 KiB[0m
libksysguard: [31;1m12.0 KiB[0m
libmd: 1.1.0 → 1.2.0, [31;1m13.8 KiB[0m
libmicrohttpd: ∅ → 1.0.5, [31;1m12.3 KiB[0m
libmicrohttpd: ∅ → 1.0.5, [31;1m8.1 KiB[0m
libmpg123: 1.33.4 → 1.33.5
libnice: 0.1.22 → 0.1.23
libopenmpt: 0.8.6 → 0.8.7
libpaper: 1.1.29 → 2.2.8, [31;1m57.1 KiB[0m
librsvg: 2.62.1 → 2.62.3, [31;1m19.5 KiB[0m
libsodium: 1.0.22-unstable-2026-04-09 → 1.0.22-unstable-2026-04-16
libssh2: [31;1m8.0 KiB[0m
libtpms: ∅ → 0.10.2-unstable-2026-05-06, [31;1m14.6 KiB[0m
libtpms: ∅ → 0.10.2-unstable-2026-05-06, [31;1m32.7 KiB[0m
libultrahdr: [32;1m-257.4 KiB[0m
libusb: 1.0.29 → 1.0.30
libusb: 1.0.29 → 1.0.30, [31;1m9.3 KiB[0m
libxi: ∅ → 1.8.3
libxkbcommon: ∅ → 1.13.2, [31;1m75.0 KiB[0m
libxkbfile: 1.1.3 → 1.2.0
libxmlb: 0.3.25 → 0.3.27
lilv: 0.26.4 → 0.28.0
linux-headers-static: 6.18.7 → 7.0, [31;1m134.6 KiB[0m
linux-headers: 6.18.7 → 7.0, [31;1m134.6 KiB[0m
linux-pam: ∅ → 1.7.2, [31;1m15.3 KiB[0m
linux-pam: ∅ → 1.7.2, [31;1m23.9 KiB[0m
llhttp: 9.4.1 → 9.4.2
llvm: [32;1m-109.8 KiB[0m
llvm: [32;1m-51.5 KiB[0m
lnav: [32;1m-112.1 KiB[0m
lttng-ust: 2.14.0 → 2.15.1, [31;1m115.9 KiB[0m
lttng-ust: 2.14.0 → 2.15.1, [31;1m67.2 KiB[0m
lvm2: ∅ → 2.03.41, [31;1m31.6 KiB[0m
lvm2: ∅ → 2.03.41, [31;1m39.7 KiB[0m
md4c: 0.5.2 → 0.5.3
mesa-libgbm: ∅ → 26.1.3
mesa: [31;1m211.5 KiB[0m
mesa: [31;1m88.0 KiB[0m
mise: 2026.7.0 → 2026.7.4, [31;1m1.9 MiB[0m
modemmanager-qt: 6.27.0 → 6.28.0
mpg123: 1.33.4 → 1.33.5
nbytes: ∅ → 0.1.4, [31;1m46.4 KiB[0m
neovim-unwrapped: 0.12.3 → 0.12.4
neovim: 0.12.3 → 0.12.4
networkmanager-qt: 6.27.0 → 6.28.0
nghttp3: ∅ → 1.16.0, [31;1m9.9 KiB[0m
ngtcp2: ∅ → 1.23.0, [31;1m114.5 KiB[0m
nh-unwrapped: 4.4.0 → 4.4.1, [32;1m-21.4 KiB[0m
nh: 4.4.0 → 4.4.1
nix-cmd: 2.34.7 → 2.34.8
nix-expr: 2.34.7 → 2.34.8
nix-fetchers: 2.34.7 → 2.34.8
nix-flake: 2.34.7 → 2.34.8
nix-index: [31;1m40.3 KiB[0m
nix-main: 2.34.7 → 2.34.8
nix-manual: 2.34.7 → 2.34.8
nix-nswrapper: 2.34.7 → 2.34.8
nix-store: 2.34.7 → 2.34.8
nix-util: 2.34.7 → 2.34.8
nix: 2.34.7 → 2.34.8
nixos-manual: [31;1m41.1 KiB[0m
nixos-rebuild-ng: [31;1m48.2 KiB[0m
nixos-system-kushtaka: 26.11.20260705.f205b55 → 26.11.20260712.3b32825, [31;1m51.7 KiB[0m
nixos-system-snallygaster: 26.11.20260705.f205b55 → 26.11.20260712.3b32825, [31;1m51.7 KiB[0m
nixos-system-wendigo: 26.11.20260705.f205b55 → 26.11.20260712.3b32825, [31;1m51.7 KiB[0m
nodejs-slim: 24.16.0 → 24.18.0, [31;1m1.8 MiB[0m
nodejs: 24.16.0 → 24.18.0, [31;1m29.9 KiB[0m
nss-cacert: 3.123, 3.123-p11kit → 3.125, 3.125-p11kit, [32;1m-8.4 KiB[0m
nvim-host-python3: 3.13.13 → 3.14.6
ocl-icd: 2.3.4 → 2.3.5, [31;1m20.6 KiB[0m
ocl-icd: 2.3.4 → 2.3.5, [31;1m39.7 KiB[0m
onnxruntime: [31;1m18.3 KiB[0m
openjdk-minimal-jre: [32;1m-40.0 KiB[0m
openjdk: [32;1m-336.0 KiB[0m
openssl: ∅ → 3.6.3
openvino: [32;1m-44.3 KiB[0m
orc: 0.4.41 → 0.4.42, [31;1m403.2 KiB[0m
orc: 0.4.41 → 0.4.42, [31;1m875.0 KiB[0m
orca: [31;1m639.8 KiB[0m
oxygen-icons: 6.27.0 → 6.28.0, [31;1m278.5 KiB[0m
pciutils: [31;1m41.6 KiB[0m
perl5.42.0-Compress-Raw-Bzip2: ∅ → 2.218, [31;1m112.4 KiB[0m
perl5.42.0-Compress-Raw-Zlib: ∅ → 2.222, [31;1m267.6 KiB[0m
perl5.42.0-Config-IniFiles: 3.000003 → 3.002000
perl5.42.0-HTML-Parser: 3.81 → 3.85
perl5.42.0-HTTP-Message: 6.45 → 7.02
perl5.42.0-IO-Compress: ∅ → 2.221, [31;1m1.7 MiB[0m
perl5.42.0-Net-DBus: [32;1m-8.1 KiB[0m
perl5.42.0-Net-SSLeay: [32;1m-20.0 KiB[0m
perl5.42.0-libwww-perl: 6.72 → 6.83, [31;1m12.5 KiB[0m
pipewire: 1.6.5 → 1.6.7, [31;1m1.9 MiB[0m
pop: 0.2.1 → 0.2.2, [31;1m1.1 MiB[0m
poppler-glib: 25.10.0 → 26.06.0, [31;1m383.2 KiB[0m
poppler-qt6: 25.10.0 → 26.06.0, [31;1m393.1 KiB[0m
poppler-utils: 25.10.0 → 26.06.0, [31;1m428.5 KiB[0m
presenterm: [32;1m-14.8 KiB[0m
prison: 6.27.0 → 6.28.0
procps: [32;1m-760.9 KiB[0m
protobuf: 34.1 → 35.1, [31;1m346.5 KiB[0m
purpose: 6.27.0 → 6.28.0
pygobject: 3.56.2 → 3.56.3
python3.11-pygobject: 3.56.2 → 3.56.3
python3.13-argcomplete: 3.6.3 → ∅, [32;1m-343.1 KiB[0m
python3.13-certifi: 2026.01.04 → ∅, [32;1m-474.0 KiB[0m
python3.13-dasbus-unstable: 11-10-2022 → ∅, [32;1m-609.6 KiB[0m
python3.13-dbus-python: 1.4.0 → ∅, [32;1m-685.3 KiB[0m
python3.13-dnspython: 2.8.0 → ∅, [32;1m-3.8 MiB[0m
python3.13-greenlet: 3.3.0 → ∅, [32;1m-1.1 MiB[0m
python3.13-gst-python: 1.26.11 → ∅, [32;1m-211.5 KiB[0m
python3.13-mako: 1.3.10 → ∅, [32;1m-1014.5 KiB[0m
python3.13-markdown: 3.10.2 → ∅, [32;1m-1.1 MiB[0m
python3.13-markupsafe: 3.0.3 → ∅, [32;1m-85.5 KiB[0m
python3.13-msgpack: 1.1.2 → ∅, [32;1m-351.3 KiB[0m
python3.13-packaging: 26.1 → ∅, [32;1m-1.1 MiB[0m
python3.13-psutil: 7.2.2 → ∅, [32;1m-1.1 MiB[0m
python3.13-pycairo: 1.29.0 → ∅, [32;1m-508.2 KiB[0m
python3.13-pycups: 2.0.4 → ∅, [32;1m-242.3 KiB[0m
python3.13-pycurl: 7.45.6 → ∅, [32;1m-441.4 KiB[0m
python3.13-pygdbmi: 0.11.0.0 → ∅, [32;1m-149.6 KiB[0m
python3.13-pygobject: 3.56.2 → ∅, [32;1m-1.2 MiB[0m
python3.13-pynvim: 0.6.0 → ∅, [32;1m-504.1 KiB[0m
python3.13-pyserial: 3.5 → ∅, [32;1m-1.1 MiB[0m
python3.13-pysmbc: 1.0.25.1 → ∅, [32;1m-101.7 KiB[0m
python3.13-pyxdg: 0.28 → ∅, [32;1m-612.7 KiB[0m
python3.13-pyyaml: 6.0.3 → ∅, [32;1m-1006.8 KiB[0m
python3.13-sentry-sdk: 2.63.0 → ∅, [32;1m-6.0 MiB[0m
python3.13-setproctitle: 1.3.7 → ∅, [32;1m-48.2 KiB[0m
python3.13-setuptools: 80.10.1 → ∅, [32;1m-11.3 MiB[0m
python3.13-tomlkit: 0.14.0 → ∅, [32;1m-620.5 KiB[0m
python3.13-urllib3: 2.6.3 → ∅, [32;1m-1.3 MiB[0m
python3.13-xmltodict: 1.0.4 → ∅, [32;1m-94.8 KiB[0m
python3.13-yq: 3.4.3 → ∅, [32;1m-162.8 KiB[0m
python3.14-argcomplete: ∅ → 3.6.3, [31;1m350.6 KiB[0m
python3.14-certifi: ∅ → 2026.04.22, [31;1m471.4 KiB[0m
python3.14-dasbus-unstable: ∅ → 11-10-2022, [31;1m618.5 KiB[0m
python3.14-dbus-python: ∅ → 1.4.0, [31;1m691.8 KiB[0m
python3.14-dnspython: ∅ → 2.8.0, [31;1m4.1 MiB[0m
python3.14-greenlet: ∅ → 3.3.0, [31;1m1.1 MiB[0m
python3.14-gst-python: ∅ → 1.28.4, [31;1m257.8 KiB[0m
python3.14-mako: ∅ → 1.3.12, [31;1m1.0 MiB[0m
python3.14-markdown: ∅ → 3.10.2, [31;1m1.2 MiB[0m
python3.14-markupsafe: ∅ → 3.0.3, [31;1m99.7 KiB[0m
python3.14-msgpack: ∅ → 1.1.2, [31;1m353.3 KiB[0m
python3.14-packaging: ∅ → 26.2, [31;1m1.2 MiB[0m
python3.14-psutil: ∅ → 7.2.2, [31;1m1.2 MiB[0m
python3.14-pycairo: ∅ → 1.29.0, [31;1m508.3 KiB[0m
python3.14-pycups: ∅ → 2.0.4, [31;1m242.3 KiB[0m
python3.14-pycurl: ∅ → 7.46.0, [31;1m540.8 KiB[0m
python3.14-pygdbmi: ∅ → 0.11.0.0, [31;1m164.6 KiB[0m
python3.14-pygobject: ∅ → 3.56.3, [31;1m1.2 MiB[0m
python3.14-pynvim: ∅ → 0.6.0, [31;1m579.3 KiB[0m
python3.14-pyserial: ∅ → 3.5, [31;1m1.1 MiB[0m
python3.14-pysmbc: ∅ → 1.0.25.1, [31;1m102.5 KiB[0m
python3.14-pyxdg: ∅ → 0.28, [31;1m630.6 KiB[0m
python3.14-pyyaml: ∅ → 6.0.3, [31;1m1012.9 KiB[0m
python3.14-sentry-sdk: ∅ → 2.64.0, [31;1m6.7 MiB[0m
python3.14-setproctitle: ∅ → 1.3.7, [31;1m49.2 KiB[0m
python3.14-setuptools: ∅ → 82.0.1, [31;1m11.0 MiB[0m
python3.14-tomlkit: ∅ → 0.14.0, [31;1m717.3 KiB[0m
python3.14-urllib3: ∅ → 2.7.0, [31;1m1.5 MiB[0m
python3.14-xmltodict: ∅ → 1.0.4, [31;1m95.9 KiB[0m
python3.14-yq: ∅ → 3.4.3, [31;1m164.6 KiB[0m
python3: 3.13.13 → 3.14.6, [31;1m13.2 MiB[0m
python3: 3.13.13 → 3.14.6, [31;1m8.0 MiB[0m
qgpgme: 2.0.0 → 2.1.0
qqc2-desktop-style: 6.27.0 → 6.28.0
qtdeclarative: [32;1m-108.6 KiB[0m
qtwebengine: [32;1m-92.0 KiB[0m
rclone: 1.74.3 → 1.74.4, [31;1m279.1 KiB[0m
ripgrep: [31;1m10.8 KiB[0m
ruff: [32;1m-51.2 KiB[0m
s2n-tls: [32;1m-48.0 KiB[0m
sd: [32;1m-14.5 KiB[0m
sdl2-compat: 2.32.68 → 2.32.70
serena-agent: [31;1m35.6 KiB[0m
signal-desktop: [32;1m-16.6 KiB[0m
signond: [32;1m-427.4 KiB[0m
socat: 1.8.1.1 → 1.8.1.3
solid: 6.27.0 → 6.28.0
sonnet: 6.27.0 → 6.28.0
sord: 0.16.20 → 0.16.22
soupsieve: 2.8.3 → 2.8.4
source: [31;1m370.5 KiB[0m
speech-dispatcher: [31;1m10.5 KiB[0m
sqlite: ∅ → 3.53.1, [31;1m362.1 KiB[0m
srt: 1.5.4 → 1.5.5, [31;1m134.6 KiB[0m
srt: 1.5.4 → 1.5.5, [31;1m288.2 KiB[0m
steam-run: [32;1m-101.7 KiB[0m
steam: [32;1m-101.7 KiB[0m
subversion-client: [31;1m21.9 KiB[0m
svt-av1: 3.1.2 → 4.1.0, [32;1m-1.1 MiB[0m
svt-av1: 3.1.2 → 4.1.0, [32;1m-773.1 KiB[0m
switch-to-configuration: [32;1m-34.6 KiB[0m
syndication: 6.27.0 → 6.28.0
syntax-highlighting: 6.27.0 → 6.28.0, [31;1m27.6 KiB[0m
system-config-printer: [31;1m8.2 KiB[0m
system: [31;1m33.8 KiB[0m
systemd-minimal-libs: 260.2 → 261, [31;1m448.2 KiB[0m
systemd-minimal: 260.2 → 261, [31;1m3.2 MiB[0m
systemd: 260.2 → 261, [31;1m1.9 MiB[0m
systemd: 260.2 → 261, [31;1m3.7 MiB[0m
thin-provisioning-tools: [31;1m39.0 KiB[0m
threadweaver: 6.27.0 → 6.28.0
tree-sitter-c-neovim: 0.12.3 → 0.12.4
tree-sitter-lua-neovim: 0.12.3 → 0.12.4
tree-sitter-markdown-neovim: 0.12.3 → 0.12.4
tree-sitter-markdown_inline-neovim: 0.12.3 → 0.12.4
tree-sitter-query-neovim: 0.12.3 → 0.12.4
tree-sitter-vim-neovim: 0.12.3 → 0.12.4
tree-sitter-vimdoc-neovim: 0.12.3 → 0.12.4
tree-sitter: 0.26.8 → 0.26.9, [32;1m-8.6 KiB[0m
trippy: [32;1m-35.3 KiB[0m
usage: 3.5.3 → 3.5.4, [32;1m-2.8 MiB[0m
util-linux-minimal: ∅ → 2.42.2, [31;1m42.7 KiB[0m
util-linux: 2.42 → 2.42.2, [31;1m240.8 KiB[0m
viddy: [32;1m-14.2 KiB[0m
vim-full: 9.2.0389 → 9.2.0541, [31;1m88.2 KiB[0m
vimplugin-fzf: 0.73.1 → 0.74.0, [31;1m40.8 KiB[0m
vimplugin-nightfox.nvim: 3.10.0-unstable-2026-05-03 → 3.10.0-unstable-2026-07-04
vimplugin-nvim-tree.lua: 1.17.0-unstable-2026-06-20 → 1.18.0
vimplugin-vim-go: 1.29-unstable-2026-03-28 → 1.29-unstable-2026-07-08
vulkan-loader: 1.4.341.0 → 1.4.350.0, [31;1m39.8 KiB[0m
vulkan-tools: 1.4.341.0 → 1.4.350.0, [31;1m19.5 KiB[0m
which: 2.23 → 2.25
x265: 4.1 → 4.2, [31;1m147.3 KiB[0m
x265: 4.1 → 4.2, [31;1m198.8 KiB[0m
xh: [31;1m22.8 KiB[0m
xorg-server: 21.1.23 → 21.1.24
xwayland: 24.1.12 → 24.1.13
xz: [31;1m228.9 KiB[0m
```

</details>