### PR TITLE
chore: update claude-code

### DIFF
--- a/pkgs/claude-code/default.nix
+++ b/pkgs/claude-code/default.nix
@@ -11,7 +11,7 @@
   callPackage,
   binName ? "claude",
 }: let
-  version = "2.1.209";
+  version = "2.1.210";
 
   platformMap = {
     "aarch64-darwin" = "darwin-arm64";
@@ -25,10 +25,10 @@
       or (throw "claude-code: unsupported platform ${stdenv.hostPlatform.system}");
 
   nativeHashes = {
-    "darwin-arm64" = "031qviyvn0m5083f6q8bshjav27jp2k4dfrvqgapabyv95zxxljr";
-    "darwin-x64" = "1im25y7lgbjik0r0awjkb2kswa79dpn0d4yvlqkvsiaxj15z9hsc";
-    "linux-x64" = "1pg9d6drarfhkg8zgs16jhxg81h200j0zx8dajbzhwkpnawg90mq";
-    "linux-arm64" = "1w72v6q25dwfm3xqjrpp0l9qp6p5p0xmglj9r72zqz11yy7bd317";
+    "darwin-arm64" = "0qn6z1828y8kdhgck8x52ykhsr0c0mg7yi3mkml84x0is5i1siqv";
+    "darwin-x64" = "0h2w2z4rf1dp2a91d35532x5yd38jzfji4qicyg85n2hh23jqbw9";
+    "linux-x64" = "06gpyvgxaggsqpcj49wv9ixmzp4q3hrwdhbzzv8wxhnl7sswxlp7";
+    "linux-arm64" = "1s3ly7ph3qf32w4rbfmbjlqrbvjd1ryd8vl3p9g3n7yrq69v3zl4";
   };
 
   nativeBinary = fetchurl {


### PR DESCRIPTION
Automated update of `pkgs/claude-code` to the latest version published on npm.

The new binary has been built and pushed to Cachix — no local build required after merge.