### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -56,11 +56,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1783779223,
-        "narHash": "sha256-W4/tstArVC8ClhQA9GnaKtYk2H19d5r9AMVfxCCUkGE=",
+        "lastModified": 1784163235,
+        "narHash": "sha256-AU2WJXK1m44+EdBEZe9MVJakk5JrwSP+8lzSGiz3enw=",
         "owner": "charmbracelet",
         "repo": "nur",
-        "rev": "54d99fa779339d6f2cb35ede4f5908fe88bcfe4e",
+        "rev": "514efc64287b1f2724d8e2f1174574955c7a7efb",
         "type": "github"
       },
       "original": {
@@ -236,11 +236,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783963347,
-        "narHash": "sha256-r376E2XpakiXwModDHIxlvB6qLq4iFVEq730vxOO4JY=",
+        "lastModified": 1784129366,
+        "narHash": "sha256-N5JiyICSeQF14x+OQebNyPpYowOT9Rs1iKyeCylSzOA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a45a7c451455a51ae740ec3bce4024b312809c29",
+        "rev": "165228b0efefc3e635e5174020c40ea64271dc25",
         "type": "github"
       },
       "original": {
@@ -317,11 +317,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1783792734,
-        "narHash": "sha256-50rvY9GdFvpYDcMLcD/4cWSi0hVxArT5wsGlVsHy8eY=",
+        "lastModified": 1784100666,
+        "narHash": "sha256-HF/mrw5NYQfKFZgkfV2h1UL5/E3ccfsE2XJ1AbbLLJ0=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "8efb4337e857949f4cfac86d12ef1066f417f31f",
+        "rev": "fccfa9031a85b78a437f2f153c1f6449f3bc3185",
         "type": "github"
       },
       "original": {
@@ -410,11 +410,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1783915482,
-        "narHash": "sha256-FmieJB8/OUvNxbkboi7+IGfIuSXY3nF/hZQm8kD0r50=",
+        "lastModified": 1784115452,
+        "narHash": "sha256-BoYPdqk6jlKXy+DyUzyGV/CtRGfAhk2MmIgBhsemTGI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6cdc7fc76e8bf7fde9fa43a849fcaaa70e230dee",
+        "rev": "35d3407a3816f3b341d8cf1d60abaf2b7b8166ac",
         "type": "github"
       },
       "original": {
@@ -426,11 +426,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1784007870,
-        "narHash": "sha256-djcLt/JJphyNt4eDY9XTly+/WbCK5lqWq9lSgCmJkkQ=",
+        "lastModified": 1784120854,
+        "narHash": "sha256-KesHgItiZPgGX740axSiQLcIQ8D24MDqNpkKYWIek8k=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "18b9261cb3294b6d2a06d03f96872827b8fe2698",
+        "rev": "753cc8a3a87467296ddd1fa93f0cc3e81120ee46",
         "type": "github"
       },
       "original": {
@@ -446,11 +446,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1784058086,
-        "narHash": "sha256-G1mx6OoEWOELmt+URlia7twBHlh3ottXewQMSegMAWk=",
+        "lastModified": 1784196425,
+        "narHash": "sha256-GPyxLV4qS2TTP7RoINrPexz0Dy5rvqT5ylzHKudyroE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "863e4db0d3df759c7c7596c3629c23c74a4722c9",
+        "rev": "0daa24ee1b821a30f7714bd269148dc47ed484a0",
         "type": "github"
       },
       "original": {
@@ -586,11 +586,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1784055985,
-        "narHash": "sha256-lABy+eXDQ/VsuhRMQeV9nho+ussel+QYl/uj/pw19Yg=",
+        "lastModified": 1784190929,
+        "narHash": "sha256-uBaJTtdTwzrvk+Y0r5RpW9FfCv9SgpZBPhldg23Gg54=",
         "owner": "oraios",
         "repo": "serena",
-        "rev": "68a2db1ba0d3069c8e5e10387f4f6d02c224d6c0",
+        "rev": "465c5eb627883ec310c5b7e643fe445af84589b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated update of `flake.lock` inputs.

All hosts built successfully against this lock file.
Merging will trigger `autodeploy.yaml`, which publishes store paths for pickup by `nixos-autodeploy`.

## Package changes

**Added: 0
0 | Removed: 0
0 | Changed: **

<details>
<summary>Full diff</summary>

```
aurorae: 6.7.2 → 6.7.3
bluedevil: 6.7.2 → 6.7.3
breeze-gtk: 6.7.2 → 6.7.3
breeze: 6.7.2, 6.7.2-qt5 → 6.7.3, 6.7.3-qt5
crush: 0.84.1 → 0.85.0, [31;1m5.1 MiB[0m
discover: 6.7.2 → 6.7.3, [31;1m15.6 KiB[0m
drkonqi: 6.7.2 → 6.7.3, [31;1m22.5 KiB[0m
envfs: 1.1.0 → 1.2.0, [31;1m181.6 KiB[0m
firefox-unwrapped: 152.0.5 → 152.0.6, [31;1m128.6 KiB[0m
firefox: 152.0.5 → 152.0.6, [32;1m-25.5 KiB[0m
gh-dash: 4.25.0 → 4.25.2, [32;1m-12.0 KiB[0m
just: 1.55.1 → 1.56.0, [31;1m71.2 KiB[0m
kactivitymanagerd: 6.7.2 → 6.7.3
kde-cli-tools: 6.7.2 → 6.7.3
kde-gtk-config: 6.7.2 → 6.7.3
kdecoration: 6.7.2 → 6.7.3
kdeplasma-addons: 6.7.2 → 6.7.3, [31;1m57.8 KiB[0m
kglobalacceld: 6.7.2 → 6.7.3
kinfocenter: 6.7.2 → 6.7.3
kmenuedit: 6.7.2 → 6.7.3
knighttime: 6.7.2 → 6.7.3
kpipewire: 6.7.2 → 6.7.3
krdp: 6.7.2 → 6.7.3
kscreen: 6.7.2 → 6.7.3
kscreenlocker: 6.7.2 → 6.7.3
ksshaskpass: 6.7.2 → 6.7.3
ksystemstats: 6.7.2 → 6.7.3
kwallet-pam: 6.7.2 → 6.7.3
kwayland-integration: 6.7.2 → 6.7.3
kwayland: 6.7.2 → 6.7.3
kwin-x11: 6.7.2 → 6.7.3
kwin: 6.7.2 → 6.7.3, [31;1m26.0 KiB[0m
kwrited: 6.7.2 → 6.7.3
layer-shell-qt: 6.7.2 → 6.7.3
libidn: 1.44 → ∅, [32;1m-429.4 KiB[0m
libidn: 1.44 → ∅, [32;1m-853.5 KiB[0m
libkscreen: 6.7.2 → 6.7.3
libksysguard: 6.7.2 → 6.7.3, [31;1m9.2 KiB[0m
liblouis: 3.33.0 → 3.38.0, [31;1m886.9 KiB[0m
libplasma: 6.7.2 → 6.7.3
libqalculate: 5.11.0 → 5.12.0, [31;1m144.7 KiB[0m
milou: 6.7.2 → 6.7.3
nixos-manual: [31;1m11.4 KiB[0m
nixos-system-kushtaka: 26.11.20260713.6cdc7fc → 26.11.20260715.35d3407
nixos-system-snallygaster: 26.11.20260713.6cdc7fc → 26.11.20260715.35d3407
nixos-system-wendigo: 26.11.20260713.6cdc7fc → 26.11.20260715.35d3407
node_exporter: 1.11.1 → 1.12.0, [31;1m96.3 KiB[0m
ocean-sound-theme: 6.7.2 → 6.7.3
plasma-activities-stats: 6.7.2 → 6.7.3
plasma-activities: 6.7.2 → 6.7.3
plasma-browser-integration: 6.7.2 → 6.7.3
plasma-desktop: 6.7.2 → 6.7.3, [31;1m130.0 KiB[0m
plasma-integration: 6.7.2, 6.7.2-qt5 → 6.7.3, 6.7.3-qt5
plasma-keyboard: 6.7.2 → 6.7.3
plasma-nano: 6.7.2 → 6.7.3
plasma-nm: 6.7.2 → 6.7.3, [31;1m19.4 KiB[0m
plasma-pa: 6.7.2 → 6.7.3
plasma-sdk: 6.7.2 → 6.7.3
plasma-systemmonitor: 6.7.2 → 6.7.3
plasma-workspace-wallpapers: 6.7.2 → 6.7.3
plasma-workspace: 6.7.2 → 6.7.3, [31;1m20.4 KiB[0m
plasma5support: 6.7.2 → 6.7.3
polkit-kde-agent: 1-6.7.2 → 1-6.7.3
pop: 0.2.2 → 0.3.0, [31;1m890.4 KiB[0m
powerdevil: 6.7.2 → 6.7.3, [31;1m15.4 KiB[0m
print-manager: 6.7.2 → 6.7.3
qqc2-breeze-style: 6.7.2 → 6.7.3
qtkeychain: 0.16.0 → 0.17.0
serena-agent: [31;1m27.1 KiB[0m
source: [31;1m144.2 KiB[0m
spectacle: 6.7.2 → 6.7.3, [31;1m16.1 KiB[0m
steam-run: [32;1m-9.1 KiB[0m
steam: [32;1m-12.4 KiB[0m
systemsettings: 6.7.2 → 6.7.3
union: 6.7.2 → 6.7.3
vimplugin-flash.nvim: 2.1.0-unstable-2025-10-28 → 2.1.0-unstable-2026-07-10
vpnc-scripts-unstable: 2023-01-03 → 2026-06-29
xdg-desktop-portal-kde: 6.7.2 → 6.7.3
```

</details>