### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -56,11 +56,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1784163235,
-        "narHash": "sha256-AU2WJXK1m44+EdBEZe9MVJakk5JrwSP+8lzSGiz3enw=",
+        "lastModified": 1784261826,
+        "narHash": "sha256-YCQ/+Lku/kIOYDAw+1QhD1W4YFYZqG13Kkh+RXkJ0R8=",
         "owner": "charmbracelet",
         "repo": "nur",
-        "rev": "514efc64287b1f2724d8e2f1174574955c7a7efb",
+        "rev": "bf4a98fee4ef3f6f2afde7c9148d0d21f0832a2d",
         "type": "github"
       },
       "original": {
@@ -236,11 +236,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784129366,
-        "narHash": "sha256-N5JiyICSeQF14x+OQebNyPpYowOT9Rs1iKyeCylSzOA=",
+        "lastModified": 1784407317,
+        "narHash": "sha256-iZrxHToDJWnvt+5LGAtvuQMTy1NZYlNEKbKaVtBJNcc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "165228b0efefc3e635e5174020c40ea64271dc25",
+        "rev": "39411a8e12a5526d992e65bc7e3dc9a4414d6713",
         "type": "github"
       },
       "original": {
@@ -275,11 +275,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783864904,
-        "narHash": "sha256-BQxN5UMg9FOevAsgBRwPxfxlh51Puj+dNn/8Dsi3sPM=",
+        "lastModified": 1784440659,
+        "narHash": "sha256-Q5kNLlWngt7TaIIZoxDKWMHjiSaNRVqr70FqWCRRfr4=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "1111b9bc836afb7e31a7014e8d1272de9b1c917d",
+        "rev": "4f8d52a3598b0dc7db7a5e7b419e3edd9d1ecfdb",
         "type": "github"
       },
       "original": {
@@ -317,11 +317,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1784100666,
-        "narHash": "sha256-HF/mrw5NYQfKFZgkfV2h1UL5/E3ccfsE2XJ1AbbLLJ0=",
+        "lastModified": 1784310968,
+        "narHash": "sha256-rkSPTePrKqs4dg+i7ZFCq93+HrClac6oSwXX927SVjA=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "fccfa9031a85b78a437f2f153c1f6449f3bc3185",
+        "rev": "779c32a00155994c86cde8213a8dd4df139d4355",
         "type": "github"
       },
       "original": {
@@ -410,11 +410,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1784115452,
-        "narHash": "sha256-BoYPdqk6jlKXy+DyUzyGV/CtRGfAhk2MmIgBhsemTGI=",
+        "lastModified": 1784364478,
+        "narHash": "sha256-CdItYNdYUlm7NxqMVyQKqT2IxTwvapiPuRLWOyHTrbY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "35d3407a3816f3b341d8cf1d60abaf2b7b8166ac",
+        "rev": "20535e48e12c86043b577b8518234ff5dbb26957",
         "type": "github"
       },
       "original": {
@@ -426,11 +426,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1784120854,
-        "narHash": "sha256-KesHgItiZPgGX740axSiQLcIQ8D24MDqNpkKYWIek8k=",
+        "lastModified": 1784356753,
+        "narHash": "sha256-12KrbMiWLcf8m7pCvAtZh1ZrgF85ZXDXvfR/fWTKy84=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "753cc8a3a87467296ddd1fa93f0cc3e81120ee46",
+        "rev": "61b7c44c4073f0b827768aff0049561b5110ea5a",
         "type": "github"
       },
       "original": {
@@ -446,11 +446,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1784196425,
-        "narHash": "sha256-GPyxLV4qS2TTP7RoINrPexz0Dy5rvqT5ylzHKudyroE=",
+        "lastModified": 1784454590,
+        "narHash": "sha256-n5jYEG4YAZOcQHfVvoD/7UM0Ea6+DWf3WxlvhdzUokE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0daa24ee1b821a30f7714bd269148dc47ed484a0",
+        "rev": "61d31fc41f72104049d2eecb38b3c80a2ea70373",
         "type": "github"
       },
       "original": {
@@ -586,11 +586,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1784190929,
-        "narHash": "sha256-uBaJTtdTwzrvk+Y0r5RpW9FfCv9SgpZBPhldg23Gg54=",
+        "lastModified": 1784372473,
+        "narHash": "sha256-Kl5jtYlN6/gzaEOOxob0HcD1UDSP5if8rEPaqZWosz4=",
         "owner": "oraios",
         "repo": "serena",
-        "rev": "465c5eb627883ec310c5b7e643fe445af84589b3",
+        "rev": "96e95c0b5dfaf21a277a1478e72c11f9383a9c9a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated update of `flake.lock` inputs.

All hosts built successfully against this lock file.
Merging will trigger `autodeploy.yaml`, which publishes store paths for pickup by `nixos-autodeploy`.

## Package changes

**Added: 0
0 | Removed: 0
0 | Changed: **

<details>
<summary>Full diff</summary>

```
accountsservice: 26.13.3 → 26.27.3
freerdp: 3.27.1 → 3.29.0, [31;1m180.3 KiB[0m
index-x86_64-linux: [31;1m12.0 KiB[0m
index-x86_64: [31;1m1.2 MiB[0m
kirigami-addons: 1.12.1 → 1.13.0, [31;1m498.3 KiB[0m
ktextaddons: 2.1.0 → 2.1.1, [31;1m47.7 KiB[0m
mcp: 1.27.0 → 1.28.1, [31;1m39.3 KiB[0m
mesa: 26.1.4 → 26.1.5, [31;1m110.6 KiB[0m
mesa: 26.1.4 → 26.1.5, [31;1m31.5 KiB[0m
nix-index-with-full-db: 0.1.10 → 0.1.11
nix-index: 0.1.10 → 0.1.11, [31;1m823.8 KiB[0m
nixos-manual: [31;1m11.2 KiB[0m
nixos-system-kushtaka: 26.11.20260715.35d3407 → 26.11.20260718.20535e4
nixos-system-snallygaster: 26.11.20260715.35d3407 → 26.11.20260718.20535e4
nixos-system-wendigo: 26.11.20260715.35d3407 → 26.11.20260718.20535e4
ntfs3g: 2026.2.25 → 2026.7.7
prismlauncher-unwrapped: 11.0.2 → 11.0.3, [31;1m20.7 KiB[0m
prismlauncher: 11.0.2 → 11.0.3
protonmail-desktop: 1.13.0 → 1.13.3, [31;1m27.3 KiB[0m
python3.14-sentry-sdk: 2.64.0 → 2.66.0, [31;1m75.7 KiB[0m
ripgrep: 15.1.0 → 15.2.0, [31;1m169.6 KiB[0m
serena-agent: 1.5.4.dev0 → 1.6.1.dev0, [31;1m19.6 KiB[0m
source: [31;1m200.2 KiB[0m
steam-run: 1.0.0.85, 1.0.0.85-fhsenv → 1.0.0.87, 1.0.0.87-fhsenv
steam-unwrapped: 1.0.0.85 → 1.0.0.87, [31;1m83.6 KiB[0m
steam: 1.0.0.85, 1.0.0.85-fhsenv → 1.0.0.87, 1.0.0.87-fhsenv
xsetroot: 1.1.3 → 1.1.4
zsh: 5.9.1 → 5.9.2, [31;1m88.3 KiB[0m
```

</details>