### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -56,11 +56,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1784261826,
-        "narHash": "sha256-YCQ/+Lku/kIOYDAw+1QhD1W4YFYZqG13Kkh+RXkJ0R8=",
+        "lastModified": 1784578141,
+        "narHash": "sha256-DlR+mlyVjltlz/ciBSWU6hW3uap7ocI+vMeDa8IVz7E=",
         "owner": "charmbracelet",
         "repo": "nur",
-        "rev": "bf4a98fee4ef3f6f2afde7c9148d0d21f0832a2d",
+        "rev": "7241ebce3604d2011cfcafb854dbd74365ba01b2",
         "type": "github"
       },
       "original": {
@@ -236,11 +236,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784407317,
-        "narHash": "sha256-iZrxHToDJWnvt+5LGAtvuQMTy1NZYlNEKbKaVtBJNcc=",
+        "lastModified": 1784690067,
+        "narHash": "sha256-t86pRs7IPs3RTMPueWvvdcxyTFrctHAv2Jl7jnjsSf8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "39411a8e12a5526d992e65bc7e3dc9a4414d6713",
+        "rev": "6d8d61567802997f9ec3086b2a837e3ef31fac16",
         "type": "github"
       },
       "original": {
@@ -410,11 +410,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1784364478,
-        "narHash": "sha256-CdItYNdYUlm7NxqMVyQKqT2IxTwvapiPuRLWOyHTrbY=",
+        "lastModified": 1784555310,
+        "narHash": "sha256-/FCliTPgiuV1owejZFNx3Ch9irdvkOfOFl+HHZ+DrtM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "20535e48e12c86043b577b8518234ff5dbb26957",
+        "rev": "421eebfd0ec7bccd4abe826ce62d7e6e83129493",
         "type": "github"
       },
       "original": {
@@ -426,11 +426,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1784356753,
-        "narHash": "sha256-12KrbMiWLcf8m7pCvAtZh1ZrgF85ZXDXvfR/fWTKy84=",
+        "lastModified": 1784497964,
+        "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "61b7c44c4073f0b827768aff0049561b5110ea5a",
+        "rev": "241313f4e8e508cb9b13278c2b0fa25b9ca27163",
         "type": "github"
       },
       "original": {
@@ -446,11 +446,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1784454590,
-        "narHash": "sha256-n5jYEG4YAZOcQHfVvoD/7UM0Ea6+DWf3WxlvhdzUokE=",
+        "lastModified": 1784715758,
+        "narHash": "sha256-CZo20+wEbAwA8dK77/SpRgQiiaHwsIO7W9uzIbAE9n8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "61d31fc41f72104049d2eecb38b3c80a2ea70373",
+        "rev": "ca2b09b1769c2da39ea0efd4f31c70e16a46e403",
         "type": "github"
       },
       "original": {
@@ -586,11 +586,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1784372473,
-        "narHash": "sha256-Kl5jtYlN6/gzaEOOxob0HcD1UDSP5if8rEPaqZWosz4=",
+        "lastModified": 1784661496,
+        "narHash": "sha256-O/bnMcxUpnzvsHeWhIIZ/wfFRtdRsj3MmQivfEH2Mqo=",
         "owner": "oraios",
         "repo": "serena",
-        "rev": "96e95c0b5dfaf21a277a1478e72c11f9383a9c9a",
+        "rev": "9debf7742ab20c40f4075f12a6aa71a3c76852e6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated update of `flake.lock` inputs.

All hosts built successfully against this lock file.
Merging will trigger `autodeploy.yaml`, which publishes store paths for pickup by `nixos-autodeploy`.

## Package changes

**Added: 28 | Removed: 2 | Changed: 29**

<details>
<summary>Full diff</summary>

```
1password: 8.12.26 → 8.12.28, [31;1m2.9 MiB[0m
anthropic: 0.59.0 → 0.117.0, [31;1m4.6 MiB[0m
chfn.pam: ε → ∅
chpasswd.pam: ε → ∅
chsh.pam: ε → ∅
claude-code-settings.json: ε → ∅
claude-code-settings: ∅ → ε
crush: 0.85.0 → 0.86.0, [31;1m252.1 KiB[0m
cups.pam: ε → ∅
firefox-unwrapped: [31;1m70.4 KiB[0m
firefox: [31;1m26.5 KiB[0m
freerdp: 3.29.0 → 3.30.0, [31;1m12.4 KiB[0m
fzf: 0.74.0 → 0.74.1, [31;1m8.7 KiB[0m
groupadd.pam: ε → ∅
groupdel.pam: ε → ∅
groupmems.pam: ε → ∅
groupmod.pam: ε → ∅
initrd-linux: 6.18.38 → 6.18.39
initrd-linux: 6.18.38 → 6.18.39, [31;1m21.0 KiB[0m
just: 1.56.0 → 1.57.0, [31;1m42.0 KiB[0m
kde.pam: ε → ∅
kitty-themes: 0-unstable-2026-06-29 → 0-unstable-2026-07-10
libwacom: 2.19.0 → 2.19.1
linux: 6.18.38 → 6.18.39, [31;1m8.9 KiB[0m
login.pam: ε → ∅
mise: [32;1m-10.8 KiB[0m
nixos-manual: [31;1m27.2 KiB[0m
nixos-option: ∅ → 26.11
nixos-system-kushtaka: 26.11.20260718.20535e4 → 26.11.20260720.421eebf
nixos-system-snallygaster: 26.11.20260718.20535e4 → 26.11.20260720.421eebf
nixos-system-wendigo: 26.11.20260718.20535e4 → 26.11.20260720.421eebf
node_exporter: 1.12.0 → 1.12.1
nss: 3.125 → 3.126, [31;1m20.9 KiB[0m
openssh: 10.3p1 → 10.4p1, [31;1m1.1 MiB[0m
other.pam: ε → ∅
pam.d: ∅ → ε, [31;1m37.7 KiB[0m
passwd.pam: ε → ∅
polkit: 1.pam → ∅
ruff: 0.15.20 → 0.15.22, [31;1m72.4 KiB[0m
runuser-l.pam: ε → ∅
runuser.pam: ε → ∅
sddm-autologin.pam: ε → ∅
sddm-greeter.pam: ε → ∅
sddm.pam: ε → ∅
serena-agent: 1.6.1.dev0 → 1.6.2.dev0, [31;1m88.8 KiB[0m
source: [31;1m82.0 KiB[0m
sshd.pam: ε → ∅
su.pam: ε → ∅
sudo.pam: ε → ∅
systemd-run0.pam: ε → ∅
systemd-user.pam: ε → ∅
usage: 3.5.4 → 3.5.5
useradd.pam: ε → ∅
userdel.pam: ε → ∅
usermod.pam: ε → ∅
vimplugin-fzf: 0.74.0 → 0.74.1, [31;1m20.1 KiB[0m
vlock.pam: ε → ∅
x86_energy_perf_policy: 6.18.38 → 6.18.39
xlock.pam: ε → ∅
```

</details>