### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -56,11 +56,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1784261826,
-        "narHash": "sha256-YCQ/+Lku/kIOYDAw+1QhD1W4YFYZqG13Kkh+RXkJ0R8=",
+        "lastModified": 1784921886,
+        "narHash": "sha256-/AUywwFIywbWPlYYNTLgdXHU52D3liR785qUy40oVeM=",
         "owner": "charmbracelet",
         "repo": "nur",
-        "rev": "bf4a98fee4ef3f6f2afde7c9148d0d21f0832a2d",
+        "rev": "6395daa6d341d226e23227d6da6fc7e491c64f3c",
         "type": "github"
       },
       "original": {
@@ -236,11 +236,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784407317,
-        "narHash": "sha256-iZrxHToDJWnvt+5LGAtvuQMTy1NZYlNEKbKaVtBJNcc=",
+        "lastModified": 1784913159,
+        "narHash": "sha256-JWq0BfjO4ktpH5USfQNQzdvHpIDT8fSKD5K7LvdMRFs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "39411a8e12a5526d992e65bc7e3dc9a4414d6713",
+        "rev": "079a3b5d1aa6a719920a51316253b7d6dd22738d",
         "type": "github"
       },
       "original": {
@@ -317,11 +317,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1784310968,
-        "narHash": "sha256-rkSPTePrKqs4dg+i7ZFCq93+HrClac6oSwXX927SVjA=",
+        "lastModified": 1784723954,
+        "narHash": "sha256-1CfD8ZUjCkTgjsneLZ/lxCHhgDfqxxE7/GX0MmsgiqA=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "779c32a00155994c86cde8213a8dd4df139d4355",
+        "rev": "a017f5b72210026af5b3ac5949f08d94380a6fbd",
         "type": "github"
       },
       "original": {
@@ -410,11 +410,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1784364478,
-        "narHash": "sha256-CdItYNdYUlm7NxqMVyQKqT2IxTwvapiPuRLWOyHTrbY=",
+        "lastModified": 1784812282,
+        "narHash": "sha256-Na4aTmdz22ovtSvcvNKaRwEWkg801hDyX6t8JqvW+sE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "20535e48e12c86043b577b8518234ff5dbb26957",
+        "rev": "6d12004108e0e4a5cfa4bd83b14477f040b15773",
         "type": "github"
       },
       "original": {
@@ -426,11 +426,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1784356753,
-        "narHash": "sha256-12KrbMiWLcf8m7pCvAtZh1ZrgF85ZXDXvfR/fWTKy84=",
+        "lastModified": 1784796856,
+        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "61b7c44c4073f0b827768aff0049561b5110ea5a",
+        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
         "type": "github"
       },
       "original": {
@@ -446,11 +446,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1784454590,
-        "narHash": "sha256-n5jYEG4YAZOcQHfVvoD/7UM0Ea6+DWf3WxlvhdzUokE=",
+        "lastModified": 1784972645,
+        "narHash": "sha256-egb2gbUaWMdfx5M2Q316xf5Rll5LgVmWVpoXAl0IYwo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "61d31fc41f72104049d2eecb38b3c80a2ea70373",
+        "rev": "76541ccb0ad31d6889ce299ea8dc142a1f84ce21",
         "type": "github"
       },
       "original": {
@@ -586,11 +586,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1784372473,
-        "narHash": "sha256-Kl5jtYlN6/gzaEOOxob0HcD1UDSP5if8rEPaqZWosz4=",
+        "lastModified": 1784925005,
+        "narHash": "sha256-ZCB2azR7H8AS+CwEB77jotUkyft20DLACjD3hBnub+8=",
         "owner": "oraios",
         "repo": "serena",
-        "rev": "96e95c0b5dfaf21a277a1478e72c11f9383a9c9a",
+        "rev": "33b042ad067a1240e457f5616b9cdfe1ff49e92c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated update of `flake.lock` inputs.

All hosts built successfully against this lock file.
Merging will trigger `autodeploy.yaml`, which publishes store paths for pickup by `nixos-autodeploy`.

## Package changes

**Added: 29 | Removed: 3 | Changed: 316**

<details>
<summary>Full diff</summary>

```
1password: 8.12.26 → 8.12.28, [31;1m2.9 MiB[0m
acl: ∅ → 2.4.0, [31;1m30.4 KiB[0m
akonadi-search: [31;1m25.8 KiB[0m
alejandra: [31;1m58.8 KiB[0m
alsa-lib: 1.2.16 → 1.2.16.1
alsa-ucm-conf: 1.2.16 → 1.2.16.1
anthropic: 0.59.0 → 0.117.0, [31;1m4.6 MiB[0m
attr: ∅ → 2.6.0, [31;1m14.0 KiB[0m
atuin: [31;1m3.3 MiB[0m
bash-completion: 2.17.0 → 2.18.0
bash-interactive: 5.3p9 → 5.3p15
bash: ∅ → 5.3p15
bat: [31;1m80.8 KiB[0m
bcachefs-tools: [31;1m190.7 KiB[0m
btrfs-progs: [32;1m-11.7 KiB[0m
c-ares: 1.34.6 → 1.34.8, [31;1m13.4 KiB[0m
cfitsio: [32;1m-8.0 KiB[0m
chfn.pam: ε → ∅
chpasswd.pam: ε → ∅
chsh.pam: ε → ∅
clang: ∅ → 21.1.8, [31;1m1.6 GiB[0m
clang: ∅ → 21.1.8, [31;1m863.7 MiB[0m
claude-code-settings.json: ε → ∅
claude-code-settings: ∅ → ε
comma: [31;1m71.6 KiB[0m
container: [32;1m-132.0 KiB[0m
crush.json: ∅ → ε
crush: 0.85.0 → 0.87.0, [31;1m764.1 KiB[0m
cups.pam: ε → ∅
delta: [31;1m201.1 KiB[0m
docker-containerd: 29.6.1 → 29.6.2, [31;1m20.0 KiB[0m
docker-runc: 29.6.1 → 29.6.2
docker-tini: 29.6.1 → 29.6.2
docker: 29.6.1 → 29.6.2
electron-unwrapped: [32;1m-100.0 KiB[0m
eza: [31;1m44.8 KiB[0m
fd: [31;1m58.7 KiB[0m
ffmpeg-headless: [32;1m-28.0 KiB[0m
ffmpeg-headless: [32;1m-76.1 KiB[0m
ffmpeg: [32;1m-68.0 KiB[0m
firefox-unwrapped: 152.0.6 → 153.0, [31;1m9.4 MiB[0m
firefox: 152.0.6 → 153.0, [31;1m45.5 KiB[0m
flac: [32;1m-23.3 KiB[0m
flac: [32;1m-58.5 KiB[0m
freerdp: 3.29.0 → 3.30.0, [31;1m12.4 KiB[0m
freetype: [32;1m-13.8 KiB[0m
fzf: 0.74.0 → 0.74.1, [31;1m8.7 KiB[0m
gawk: 5.4.0 → 5.4.1, [31;1m87.9 KiB[0m
gcc: ∅ → 15.3.0
gfortran: 15.2.0 → 15.3.0, [32;1m-8.4 KiB[0m
ghostscript-with-X: [32;1m-11.9 KiB[0m
giflib: [32;1m-8.0 KiB[0m
git-minimal: 2.54.0 → 2.55.0, [31;1m892.1 KiB[0m
git-with-svn: 2.54.0 → 2.55.0, [31;1m1.1 MiB[0m
git: 2.54.0 → 2.55.0, [31;1m1.0 MiB[0m
glibc: [32;1m-40.3 KiB[0m
glibc: [32;1m-44.4 KiB[0m
go: 1.26.4 → 1.26.5, [31;1m55.2 KiB[0m
gpgme: 2.1.0 → 2.1.2
groupadd.pam: ε → ∅
groupdel.pam: ε → ∅
groupmems.pam: ε → ∅
groupmod.pam: ε → ∅
gssdp: 1.6.5 → 1.6.6
gst-plugins-bad: [32;1m-11.6 KiB[0m
harfbuzz: [32;1m-10.1 KiB[0m
hdrhistogram_c: 0.11.9 → 0.11.10, [31;1m45.8 KiB[0m
hwdata: 0.408 → 0.409, [31;1m98.1 KiB[0m
icu4c: ∅ → 78.3, [31;1m2.7 MiB[0m
imagemagick: [32;1m-16.0 KiB[0m
initrd-linux: 6.18.38 → 6.18.39, [32;1m-376.4 KiB[0m
initrd-linux: 6.18.38 → 6.18.39, [32;1m-383.6 KiB[0m
initrd-linux: 6.18.38 → 6.18.39, [32;1m-384.7 KiB[0m
intel-compute-runtime-legacy1: [32;1m-12.1 KiB[0m
intel-graphics-compiler: [32;1m-309.3 KiB[0m
jemalloc: [31;1m298.6 KiB[0m
jujutsu: [31;1m1.2 MiB[0m
just: 1.56.0 → 1.57.0, [31;1m119.7 KiB[0m
kde.pam: ε → ∅
kdeplasma-addons: [31;1m242.4 KiB[0m
kitty-themes: 0-unstable-2026-06-29 → 0-unstable-2026-07-10
kitty: 0.47.4 → 0.48.0, [31;1m327.0 KiB[0m
kwin: [31;1m53.5 KiB[0m
lerc: ∅ → 4.1.1, [32;1m-21.5 KiB[0m
libadwaita: 1.9.1 → 1.9.2
libapparmor: 5.0.0 → 5.0.1
libdovi: [32;1m-25.6 KiB[0m
libdrm: [32;1m-8.0 KiB[0m
libetebase: [31;1m423.3 KiB[0m
libevent: ∅ → 2.1.13
libffi: ∅ → 3.7.0, [31;1m31.3 KiB[0m
libjxl: 0.11.2 → 0.12.0, [32;1m-363.3 KiB[0m
libmpg123: 1.33.5 → 1.33.6
libmpg123: 1.33.5 → 1.33.6, [32;1m-11.9 KiB[0m
libopenmpt: [31;1m18.3 KiB[0m
libopenmpt: [31;1m36.8 KiB[0m
libplasma: [31;1m17.1 KiB[0m
libqalculate: [32;1m-8.4 KiB[0m
libraw: [32;1m-8.0 KiB[0m
libressl: 4.2.1 → 4.3.2, [31;1m14.9 KiB[0m
librsvg: [31;1m439.8 KiB[0m
libseccomp: ∅ → 2.6.1
libva-minimal: 2.23.0 → 2.24.0
libva-minimal: 2.23.0 → 2.24.0, [31;1m12.4 KiB[0m
libva: 2.23.0 → 2.24.0
libva: 2.23.0 → 2.24.0, [31;1m12.5 KiB[0m
libvlc: [31;1m8.0 KiB[0m
libvmaf: [32;1m-12.5 KiB[0m
libvmaf: [32;1m-20.5 KiB[0m
libwacom: 2.19.0 → 2.19.1
libwebp: [32;1m-8.0 KiB[0m
libxfont_2: 2.0.7 → 2.0.8
linux: 6.18.38 → 6.18.39, [32;1m-12.9 KiB[0m
llvm: [31;1m15.7 KiB[0m
llvm: [31;1m57.0 KiB[0m
lnav: [31;1m928.2 KiB[0m
login.pam: ε → ∅
make-initrd-ng: [31;1m14.4 KiB[0m
mangohud: [32;1m-25.3 KiB[0m
mariadb-server: [32;1m-68.4 KiB[0m
merve: ∅ → 1.2.2, [31;1m106.3 KiB[0m
mesa: [31;1m155.0 KiB[0m
mesa: [31;1m499.2 KiB[0m
mise: 2026.7.5 → 2026.7.10, [31;1m7.7 MiB[0m
moby: 29.6.1 → 29.6.2
mpg123: 1.33.5 → 1.33.6
mpg123: 1.33.5 → 1.33.6, [32;1m-11.9 KiB[0m
mupdf: [32;1m-12.0 KiB[0m
networkmanager: [32;1m-12.0 KiB[0m
networkmanager: [32;1m-8.0 KiB[0m
nh-unwrapped: [31;1m381.8 KiB[0m
nix-fetchers: [31;1m8.4 KiB[0m
nix-index: [31;1m514.6 KiB[0m
nixos-autodeploy: [31;1m236.4 KiB[0m
nixos-manual: [31;1m34.1 KiB[0m
nixos-option: ∅ → 26.11
nixos-system-kushtaka: 26.11.20260718.20535e4 → 26.11.20260723.6d12004
nixos-system-snallygaster: 26.11.20260718.20535e4 → 26.11.20260723.6d12004
nixos-system-wendigo: 26.11.20260718.20535e4 → 26.11.20260723.6d12004
node_exporter: 1.12.0 → 1.12.1, [31;1m8.0 KiB[0m
nodejs-slim: [31;1m12.6 KiB[0m
nsncd: [31;1m37.2 KiB[0m
nss: 3.125 → 3.126, [31;1m16.9 KiB[0m
onnxruntime: 1.26.0 → 1.27.1, [31;1m1.4 MiB[0m
openal-soft: [32;1m-8.7 KiB[0m
opencv: [32;1m-20.0 KiB[0m
openjdk: 17.0.20+2, 25.0.4+1 → 17.0.20+8, 25.0.4+7, [31;1m711.8 KiB[0m
openjpeg: [32;1m-10.7 KiB[0m
openresolv: 3.17.0 → 3.17.4
openssh: 10.3p1 → 10.4p1, [31;1m1.1 MiB[0m
openvino: [32;1m-732.2 KiB[0m
other.pam: ε → ∅
pam.d: ∅ → ε, [31;1m37.7 KiB[0m
passwd.pam: ε → ∅
pciutils: [31;1m16.8 KiB[0m
pcre2: ∅ → 10.47, [31;1m40.4 KiB[0m
pipewire: 1.6.7 → 1.6.8, [32;1m-19.4 KiB[0m
pipewire: 1.6.7 → 1.6.8, [32;1m-51.1 KiB[0m
polkit: 1.pam → ∅
poppler-glib: [32;1m-13.1 KiB[0m
poppler-qt6: [32;1m-13.2 KiB[0m
poppler-utils: [32;1m-13.1 KiB[0m
presenterm: [31;1m167.9 KiB[0m
publicsuffix-list: 0-unstable-2026-05-13 → 0-unstable-2026-06-24
python3.14-certifi: 2026.04.22 → 2026.06.17
python3.14-greenlet: 3.3.0 → 3.5.3, [31;1m140.0 KiB[0m
python3.14-msgpack: 1.1.2 → 1.2.1
python3.14-setuptools: 82.0.1 → 83.0.0, [31;1m15.6 KiB[0m
python3.14-tomlkit: 0.14.0 → 0.15.0, [31;1m94.9 KiB[0m
python3: [31;1m16.3 KiB[0m
python3: [31;1m17.0 KiB[0m
qgpgme: 2.1.0 → 2.2.0, [31;1m75.3 KiB[0m
qtdeclarative: [31;1m8.4 KiB[0m
qtquick3d: [32;1m-15.6 KiB[0m
qtwebengine: [31;1m87.9 KiB[0m
rclone: [31;1m8.0 KiB[0m
ripgrep: [31;1m354.6 KiB[0m
ruby: [31;1m29.3 KiB[0m
ruff: 0.15.20 → 0.15.22, [31;1m1.2 MiB[0m
runuser-l.pam: ε → ∅
runuser.pam: ε → ∅
sbc: [32;1m-8.0 KiB[0m
sd-switch: [31;1m115.3 KiB[0m
sd: [31;1m47.2 KiB[0m
sddm-autologin.pam: ε → ∅
sddm-greeter.pam: ε → ∅
sddm.pam: ε → ∅
sdl3: 3.4.10 → 3.4.12, [31;1m28.7 KiB[0m
serd: 0.32.8 → 0.32.10
serena-agent: 1.6.1.dev0 → 1.6.2.dev0, [31;1m113.9 KiB[0m
settings.json: ε → ∅
signal-desktop: 8.15.0 → 8.18.0, [31;1m428.8 KiB[0m
slang: [32;1m-16.0 KiB[0m
slang: [32;1m-8.0 KiB[0m
source: [31;1m1.4 MiB[0m
sqlite: 3.53.1 → 3.53.3, [31;1m51.6 KiB[0m
srt: [31;1m11.4 KiB[0m
srt: [31;1m9.9 KiB[0m
sshd.pam: ε → ∅
starship: [31;1m1.1 MiB[0m
steam-run: [31;1m131.5 KiB[0m
steam: [31;1m135.6 KiB[0m
stylua: [31;1m377.8 KiB[0m
su.pam: ε → ∅
sudo.pam: ε → ∅
switch-to-configuration: [31;1m68.1 KiB[0m
systemd-run0.pam: ε → ∅
systemd-user.pam: ε → ∅
systemd: [32;1m-17.5 KiB[0m
systemd: [32;1m-8.5 KiB[0m
tesseract: [32;1m-8.5 KiB[0m
thin-provisioning-tools: [31;1m123.9 KiB[0m
tpm2-tools: 5.7 → 5.8, [31;1m81.9 KiB[0m
tree-sitter-angular: 0.0.0+rev=f0d0685 → 0.0.0+rev=38a8014
tree-sitter-apex: 0.0.0+rev=3597575 → 0.0.0+rev=27a3091, [31;1m29.2 KiB[0m
tree-sitter-beancount: 0.0.0+rev=429cff8 → 0.0.0+rev=c8a9780, [31;1m11.5 KiB[0m
tree-sitter-blade: 0.0.0+rev=b9436b7 → 0.0.0+rev=5dbdcb0
tree-sitter-bpftrace: 0.0.0+rev=774f445 → 0.0.0+rev=50b27d8
tree-sitter-c3: 0.0.0+rev=78e2ae9 → 0.0.0+rev=1c6a952, [32;1m-124.6 KiB[0m
tree-sitter-c: 0.0.0+rev=ae19b67 → 0.0.0+rev=b780e47
tree-sitter-c_sharp: 0.0.0+rev=8836663 → 0.0.0+rev=v0.23.5, [31;1m92.0 KiB[0m
tree-sitter-cmake: 0.0.0+rev=c7b2a71 → 0.0.0+rev=ca627bb
tree-sitter-cue: 0.0.0+rev=20bb919 → 0.0.0+rev=dd7b90e, [31;1m28.0 KiB[0m
tree-sitter-d: 0.0.0+rev=fb028c8 → 0.0.0+rev=64f2793, [32;1m-19.1 KiB[0m
tree-sitter-dart: 0.0.0+rev=0fc19c3 → 0.0.0+rev=be07cf7, [31;1m156.7 KiB[0m
tree-sitter-devicetree: 0.0.0+rev=e685f1f → 0.0.0+rev=e78bf56
tree-sitter-diff: 0.0.0+rev=2520c3f → 0.0.0+rev=7d20331
tree-sitter-djot: 0.0.0+rev=74fac1f → 0.0.0+rev=759a618
tree-sitter-elixir: 0.0.0+rev=7937d3b → 0.0.0+rev=c4f9f5a
tree-sitter-elm: 0.0.0+rev=6d9511c → 0.0.0+rev=6bf1558
tree-sitter-enforce: 0.0.0+rev=eb27968 → 0.0.0+rev=d222ea5
tree-sitter-erlang: 0.0.0+rev=1d78195 → 0.0.0+rev=836aa2b, [31;1m36.1 KiB[0m
tree-sitter-faust: 0.0.0+rev=122dd10 → 0.0.0+rev=6074204
tree-sitter-fish: 0.0.0+rev=fa2143f → 0.0.0+rev=f435b0b
tree-sitter-forth: 0.0.0+rev=360ef13 → 0.0.0+rev=7190f21
tree-sitter-fortran: 0.0.0+rev=be30d90 → 0.0.0+rev=7edacd2, [32;1m-13.2 KiB[0m
tree-sitter-fsharp: 0.0.0+rev=1c2d935 → 0.0.0+rev=148ea97, [31;1m5.0 MiB[0m
tree-sitter-gap: 0.0.0+rev=ed2480d → 0.0.0+rev=96fe2e4
tree-sitter-git_rebase: 0.0.0+rev=760ba8e → 0.0.0+rev=32686d6
tree-sitter-gitcommit: 0.0.0+rev=33fe854 → 0.0.0+rev=49715a9
tree-sitter-gleam: 0.0.0+rev=0bb1b0a → 0.0.0+rev=cefbd68, [31;1m8.0 KiB[0m
tree-sitter-glimmer: 0.0.0+rev=88af855 → 0.0.0+rev=c67a736
tree-sitter-glimmer_javascript: 0.0.0+rev=5cc865a → 0.0.0+rev=d9cf7a2
tree-sitter-gnuplot: 0.0.0+rev=8923c1e → 0.0.0+rev=20a9829, [32;1m-2.0 MiB[0m
tree-sitter-gren: 0.0.0+rev=c36aac5 → 0.0.0+rev=cecd8ce, [31;1m8.2 KiB[0m
tree-sitter-groovy: 0.0.0+rev=781d9cd → 0.0.0+rev=deb0dcf
tree-sitter-haskell: 0.0.0+rev=7fa19f1 → 0.0.0+rev=98aedbd
tree-sitter-hlsplaylist: 0.0.0+rev=3bfda92 → ∅, [32;1m-23.9 KiB[0m
tree-sitter-htmldjango: 0.0.0+rev=3a64316 → 0.0.0+rev=a103188
tree-sitter-idl: 0.0.0+rev=fb65762 → 0.0.0+rev=f319b8b, [31;1m51.9 KiB[0m
tree-sitter-inko: 0.0.0+rev=v0.5.1 → 0.0.0+rev=v0.8.0, [31;1m25.5 KiB[0m
tree-sitter-ispc: 0.0.0+rev=9b2f9ae → 0.0.0+rev=ba1bb38, [32;1m-201.0 KiB[0m
tree-sitter-janet_simple: 0.0.0+rev=d183186 → 0.0.0+rev=3c1bdcf
tree-sitter-javadoc: 0.0.0+rev=e2f56b4 → 0.0.0+rev=51b55fb
tree-sitter-jinja: 0.0.0+rev=413dba9 → 0.0.0+rev=c213d37, [31;1m28.1 KiB[0m
tree-sitter-jinja_inline: 0.0.0+rev=413dba9 → 0.0.0+rev=c213d37, [31;1m44.4 KiB[0m
tree-sitter-json5: 0.0.0+rev=aa630ef → 0.0.0+rev=248b856
tree-sitter-julia: 0.0.0+rev=8454f26 → 0.0.0+rev=60fc237
tree-sitter-kcl: 0.0.0+rev=b0b2eb3 → 0.0.0+rev=026f40f
tree-sitter-kitty: 0.0.0+rev=fa6ab3f → 0.0.0+rev=4d93f64
tree-sitter-kos: 0.0.0+rev=03b261c → 0.0.0+rev=a733862
tree-sitter-kotlin: 0.0.0+rev=93bfeee → 0.0.0+rev=c8ac3d2, [31;1m716.1 KiB[0m
tree-sitter-koto: 0.0.0+rev=f8b3f62 → 0.0.0+rev=e8d41cb, [31;1m680.0 KiB[0m
tree-sitter-liquid: 0.0.0+rev=9566ca7 → 0.0.0+rev=e45dbac, [31;1m12.6 KiB[0m
tree-sitter-m68k: 0.0.0+rev=e128454 → 0.0.0+rev=ab9f2ad
tree-sitter-markdown: 0.0.0+rev=f969cd3 → 0.0.0+rev=c357072
tree-sitter-markdown_inline: 0.0.0+rev=f969cd3 → 0.0.0+rev=c357072
tree-sitter-matlab: 0.0.0+rev=c2390a5 → 0.0.0+rev=c9ef947
tree-sitter-meson: 0.0.0+rev=c84f354 → 0.0.0+rev=aa8d472
tree-sitter-mlir: 0.0.0+rev=96fa0ad → 0.0.0+rev=a5bcbd0
tree-sitter-muttrc: 0.0.0+rev=173b0ab → ∅, [32;1m-192.5 KiB[0m
tree-sitter-nickel: 0.0.0+rev=b5b6cc3 → 0.0.0+rev=7780a16
tree-sitter-nim: 0.0.0+rev=3878440 → 0.0.0+rev=ac72ba3, [32;1m-3.2 MiB[0m
tree-sitter-nix: 0.0.0+rev=eabf968 → 0.0.0+rev=3d0173d
tree-sitter-nu: 0.0.0+rev=696d257 → 0.0.0+rev=d694570
tree-sitter-ocaml: 0.0.0+rev=5a979b3 → 0.0.0+rev=527d62e, [31;1m657.1 KiB[0m
tree-sitter-ocaml_interface: 0.0.0+rev=5a979b3 → 0.0.0+rev=527d62e, [31;1m661.0 KiB[0m
tree-sitter-perl: 0.0.0+rev=ea9667d → 0.0.0+rev=c3e17b3, [31;1m1.3 MiB[0m
tree-sitter-php: 0.0.0+rev=3f2465c → 0.0.0+rev=3821698
tree-sitter-php_only: 0.0.0+rev=3f2465c → 0.0.0+rev=3821698
tree-sitter-pkl: 0.0.0+rev=f5beed1 → 0.0.0+rev=3486521, [31;1m12.2 KiB[0m
tree-sitter-pod: 0.0.0+rev=57c606a → 0.0.0+rev=ffbd7f3
tree-sitter-powershell: 0.0.0+rev=73800ec → 0.0.0+rev=e7bd348
tree-sitter-problog: 0.0.0+rev=d8d415f → ∅, [32;1m-29.3 KiB[0m
tree-sitter-prolog: 0.0.0+rev=d8d415f → ∅, [32;1m-29.3 KiB[0m
tree-sitter-proto: 0.0.0+rev=d65a18c → 0.0.0+rev=cf8e4eb
tree-sitter-ql: 0.0.0+rev=1fd627a → 0.0.0+rev=5b8ee9a
tree-sitter-qmldir: 0.0.0+rev=6b2b5e4 → 0.0.0+rev=c57e008
tree-sitter-qmljs: 0.0.0+rev=0bec435 → 0.0.0+rev=de96ed6, [31;1m12.0 KiB[0m
tree-sitter-query: 0.0.0+rev=fc5409c → 0.0.0+rev=8e9e223
tree-sitter-r: 0.0.0+rev=0e6ef77 → 0.0.0+rev=58a2279
tree-sitter-racket: 0.0.0+rev=54649be → 0.0.0+rev=e2b8064
tree-sitter-razor: 0.0.0+rev=fe46ce5 → 0.0.0+rev=900f53d, [32;1m-336.6 KiB[0m
tree-sitter-rego: 0.0.0+rev=ddd39af → 0.0.0+rev=7f8a431, [31;1m16.0 KiB[0m
tree-sitter-requirements: 0.0.0+rev=caeb2ba → 0.0.0+rev=2c3bb29
tree-sitter-rescript: 0.0.0+rev=43c2f1f → 0.0.0+rev=19ed8a8, [31;1m183.5 KiB[0m
tree-sitter-rst: 0.0.0+rev=4e562e1 → 0.0.0+rev=a60f107
tree-sitter-scala: 0.0.0+rev=14c5cfd → 0.0.0+rev=4d081d9, [31;1m99.8 KiB[0m
tree-sitter-sflog: 0.0.0+rev=3597575 → 0.0.0+rev=27a3091
tree-sitter-slim: 0.0.0+rev=a06113f → 0.0.0+rev=d4ff7e3
tree-sitter-slint: 0.0.0+rev=4d7ad06 → 0.0.0+rev=68b2524, [31;1m8.0 KiB[0m
tree-sitter-soql: 0.0.0+rev=3597575 → 0.0.0+rev=27a3091
tree-sitter-sosl: 0.0.0+rev=3597575 → 0.0.0+rev=27a3091
tree-sitter-ssh_config: 0.0.0+rev=71d2693 → 0.0.0+rev=b7db80e, [31;1m16.3 KiB[0m
tree-sitter-superhtml: 0.0.0+rev=8b5bb27 → 0.0.0+rev=d4d81e1
tree-sitter-swift: 0.0.0+rev=8abb3e8 → 0.0.0+rev=28fe3a8, [31;1m408.2 KiB[0m
tree-sitter-systemverilog: 0.0.0+rev=2939285 → 0.0.0+rev=aa09b90, [32;1m-148.0 KiB[0m
tree-sitter-t32: 0.0.0+rev=3bce397 → 0.0.0+rev=acc92b0
tree-sitter-tact: 0.0.0+rev=a6267c2 → 0.0.0+rev=1c689f0
tree-sitter-templ: 0.0.0+rev=1c6db04 → 0.0.0+rev=04bae7c
tree-sitter-tmux: 0.0.0+rev=75d1b99 → ∅, [32;1m-4.3 MiB[0m
tree-sitter-twig: 0.0.0+rev=7195ee5 → 0.0.0+rev=0afd9a6
tree-sitter-v: 0.0.0+rev=095865d → 0.0.0+rev=925d457
tree-sitter-vhdl: 0.0.0+rev=c2d9be3 → 0.0.0+rev=e97406d, [31;1m8.0 KiB[0m
tree-sitter-vim: 0.0.0+rev=3092fcd → 0.0.0+rev=039c8d0, [31;1m24.0 KiB[0m
tree-sitter-vimdoc: 0.0.0+rev=f061895 → 0.0.0+rev=23daa41
tree-sitter-wit: 0.0.0+rev=v1.3.0 → 0.0.0+rev=v1.4.0, [32;1m-23.8 KiB[0m
tree-sitter-yaml: 0.0.0+rev=4463985 → 0.0.0+rev=a1c4812
tree-sitter-zathurarc: 0.0.0+rev=0554b4a → ∅, [32;1m-23.9 KiB[0m
tree-sitter-zsh: 0.0.0+rev=bd344c2 → 0.0.0+rev=7a59340, [31;1m24.0 KiB[0m
tree-sitter: [31;1m425.3 KiB[0m
trippy: [31;1m287.4 KiB[0m
usage: 3.5.4 → 3.5.5, [31;1m236.0 KiB[0m
useradd.pam: ε → ∅
userdel.pam: ε → ∅
usermod.pam: ε → ∅
util-linux-minimal: [32;1m-8.0 KiB[0m
viddy: [31;1m385.1 KiB[0m
vim-full: 9.2.0541 → 9.2.0782, [31;1m124.7 KiB[0m
vimplugin-fzf: 0.74.0 → 0.74.1, [31;1m20.1 KiB[0m
vimplugin-nvim-treesitter: 0.10.0-unstable-2026-04-03 → 0.10.0-unstable-2026-07-19, [32;1m-9.8 KiB[0m
vimplugin-vim-go: 1.29-unstable-2026-07-08 → 1.29-unstable-2026-07-18
vlc: [31;1m8.0 KiB[0m
vlock.pam: ε → ∅
vpl-gpu-rt: [32;1m-29.6 KiB[0m
vulkan-tools: [32;1m-17.8 KiB[0m
wayland: ∅ → 1.26.0, [31;1m12.5 KiB[0m
x86_energy_perf_policy: 6.18.38 → 6.18.39
xgcc: ∅ → 15.3.0
xh: [31;1m318.9 KiB[0m
xkeyboard-config: ∅ → 2.48, [31;1m25.9 KiB[0m
xlock.pam: ε → ∅
xorg-server: [32;1m-8.0 KiB[0m
xrdb: 1.2.2 → 1.2.3
xset: 1.2.5 → 1.2.6
zix: 0.6.2 → 0.8.2
zix: 0.6.2 → 0.8.2, [31;1m10.1 KiB[0m
zoxide: [31;1m27.0 KiB[0m
```

</details>