### PR TITLE
Switch displays to Retrorama theme for arcade layout

### DIFF
--- a/home/roles/arcade/default.nix
+++ b/home/roles/arcade/default.nix
@@ -100,16 +100,25 @@
   # Expand a system's slot list into the absolute paths the module wants. The
   # module imposes no directory convention, so this cabinet's convention
   # (<root>/<system>/<slot>) lives here.
-  artworkFor = name:
-    lib.genAttrs media.systems.${name}.slots
-    (slot: "${media.root}/${name}/${slot}");
+  #
+  # Retrorama reads only the `snap` and `flyer` artwork slots. Box art is synced
+  # under `boxart`, so point `flyer` at that same directory rather than syncing
+  # 20GB a second time under another name. MAME has no box art, so it keeps
+  # `snap` alone and its flyer panel stays empty.
+  artworkFor = name: let
+    base =
+      lib.genAttrs media.systems.${name}.slots
+      (slot: "${media.root}/${name}/${slot}");
+  in
+    base
+    // lib.optionalAttrs (lib.elem "boxart" media.systems.${name}.slots) {
+      flyer = "${media.root}/${name}/boxart";
+    };
 
-  # Cosmo layout per display: MAME gets the arcade layout, consoles get the
-  # snes-n64 layout, which requests box/cart art rather than marquee/flyer.
-  layoutFor = name:
-    if name == "mame"
-    then "cosmo-arcade"
-    else "cosmo-snes-n64";
+  # Retrorama is one layout for every display; which system's assets it uses
+  # comes from a per-display `system` option (see displays below), not from
+  # separate layout directories the way cosmo worked.
+  retroramaLayout = "retrorama";
 in {
   imports = [
     ../cli.nix
@@ -198,10 +207,16 @@ in {
     # emulator's short name (e.g. "mame"): the module renders `display\t<key>`
     # verbatim, and that string is the join key art lookup depends on
     # (ADR-0012) — it must come out as "MAME", not "mame".
+    # `system` is a Retrorama layout option declared per_display, which
+    # attract-mode stores as a plain key inside the display section
+    # (FeDisplayInfo::process_setting routes unrecognised keys to
+    # m_layout_per_display_params, and FeDisplayInfo::save writes them back
+    # there) — so it belongs in extraSettings, not a layout_config section.
     displays = lib.mapAttrs' (name: def:
       lib.nameValuePair def.system {
-        layout = layoutFor name;
+        layout = retroramaLayout;
         romlist = name;
+        extraSettings.system = media.systems.${name}.retroramaSystem;
       })
     emulators;
   };

--- a/home/roles/arcade/media.nix
+++ b/home/roles/arcade/media.nix
@@ -7,7 +7,8 @@
 #
 # `hyperspinFolder` is the source folder name under the HyperSpin Media tree and
 # is consumed only by scripts/arcade-media-sync.py. `slots` are the attract-mode
-# artwork slots the cosmo layout for that system requests.
+# artwork slots synced for that system. `retroramaSystem` is the theme's own
+# asset-folder name, which matches neither of the others.
 {
   # Where the sync script deposits art on the cabinet.
   root = "/mnt/roms/media";
@@ -15,29 +16,38 @@
   systems = {
     mame = {
       hyperspinFolder = "MAME";
+      retroramaSystem = "Arcade";
       # No marquee/flyer: HyperSpin's MAME/Images holds only Wheel, plus genre
       # headers (Special) and one Pointer (Other).
       slots = ["wheel" "snap"];
     };
     nes = {
       hyperspinFolder = "Nintendo Entertainment System";
+      retroramaSystem = "Nintendo Entertainment System";
       slots = ["wheel" "snap" "boxart" "cartart"];
     };
     snes = {
       hyperspinFolder = "Super Nintendo Entertainment System";
+      retroramaSystem = "Super Nintendo Entertainment System";
       slots = ["wheel" "snap" "boxart" "cartart"];
     };
     genesis = {
       hyperspinFolder = "Sega Genesis";
+      retroramaSystem = "Sega Genesis";
       slots = ["wheel" "snap" "boxart" "cartart"];
     };
     gameboy = {
       hyperspinFolder = "Gameboy";
+      # Retrorama ships no Game Boy folder; one is built by hand from HyperSpin
+      # assets. Without it the layout points at a nonexistent directory.
+      retroramaSystem = "Nintendo Game Boy";
       # No cartridge scans exist for Game Boy in this library.
       slots = ["wheel" "snap" "boxart"];
     };
     atari2600 = {
       hyperspinFolder = "Atari 2600";
+      # Retrorama ships no Atari 2600 folder either; also built by hand.
+      retroramaSystem = "Atari 2600";
       # Cover art only; no cartridge scans.
       slots = ["wheel" "snap" "boxart"];
     };


### PR DESCRIPTION
Retrorama is a 4:3-native theme whose system-bg.png assets are authored at 1280x1024 — the cabinet's exact resolution. Cosmo assumed 16:9 and stretched every vertical fraction by 42% on this 5:4 panel.

One layout serves all six displays; which system's assets it uses comes from a per-display `system` option. attract-mode stores per_display layout options as plain keys inside the display section (FeDisplayInfo::process_setting -> m_layout_per_display_params), so extraSettings expresses it and the module needs no change.

Retrorama reads only `snap` and `flyer`, so `flyer` is pointed at the already-synced boxart directories rather than re-syncing 20GB under a new name.