### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -56,11 +56,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1785262582,
-        "narHash": "sha256-affZ/rj7a9n+OC2S/SEl65qUc2/zsEbd2ggCl2Nlhxw=",
+        "lastModified": 1785559318,
+        "narHash": "sha256-u5aemaCnIh6NymKZE5PXcxAwMLH8vfD1MFl/CUJ1Ow4=",
         "owner": "charmbracelet",
         "repo": "nur",
-        "rev": "7a40c001f6592c0bac09f7e935e36b01c0e8b986",
+        "rev": "ad72c13b7374e7153db65829a6ab69c6c272bcac",
         "type": "github"
       },
       "original": {
@@ -236,11 +236,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785496534,
-        "narHash": "sha256-EASdusMYLuPhOCrE3LmsAGOvGhX3vnKBLxFvj9lI8tU=",
+        "lastModified": 1785531816,
+        "narHash": "sha256-vkMnV0JIyw+g/NmcfoajlGaAO+9a0ezia+FZohQJrik=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e8827fbbb12015a8dd9f66285aec79d655bcb9f6",
+        "rev": "bf9ce9fec78f95f374e8dd3b503863a3ec128ebe",
         "type": "github"
       },
       "original": {
@@ -394,11 +394,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1785301185,
-        "narHash": "sha256-eoS3KQTO0aPWXZvIaRbRAzSSHW3l5wdMFXtT1ISfoKA=",
+        "lastModified": 1785483748,
+        "narHash": "sha256-M4HXpLsR7iFTNQfD/q+zK8/QeRYztYVDVIdIgCVGGZ0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9bc02893134c733dd85de46ee4fb2fac696b5529",
+        "rev": "59ea0b1c043c463e39fcb3cfb9a5c8bcf0777c72",
         "type": "github"
       },
       "original": {
@@ -430,11 +430,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1785505257,
-        "narHash": "sha256-iTaOwL7WSLgtTQwRTfD1rDwIH5eJlZgN915bgrppfOc=",
+        "lastModified": 1785578044,
+        "narHash": "sha256-bVjc5fQ1TLoQgYkjp6bJTesX2QbIst2te4rTHJhj62Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7601b9b32f5f20211819abd7a0976ff1b7b2e921",
+        "rev": "9d367a00c93c42f1ae2fa500c2a5dc3aca04d636",
         "type": "github"
       },
       "original": {
@@ -569,11 +569,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1785401039,
-        "narHash": "sha256-GKuqZueDX2oewucKUhN4q/0Y36THDrc9Ex89mEHpIZE=",
+        "lastModified": 1785577472,
+        "narHash": "sha256-UpBE/05qbT9Nd7dO3zOP7nQvo0kSEDOf/9zDj9dXB7A=",
         "owner": "oraios",
         "repo": "serena",
-        "rev": "dd12fa032f473a53595763b8d731817e19c15475",
+        "rev": "c74373e29a8bdafdbfc6c6a8f7d7b92301ae1f81",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated update of `flake.lock` inputs.

All hosts built successfully against this lock file.
Merging will trigger `autodeploy.yaml`, which publishes store paths for pickup by `nixos-autodeploy`.

## Package changes

**Added: 0
0 | Removed: 0
0 | Changed: **

<details>
<summary>Full diff</summary>

```
crush: 0.87.0 → 0.88.0, [32;1m-196.0 KiB[0m
dee-unstable: 2017-06-16 → ∅, [32;1m-374.7 KiB[0m
dee: ∅ → 1.2.7-unstable-2017-06-16, [31;1m374.7 KiB[0m
electron-unwrapped: 41.9.1, 42.5.1 → 41.10.3, 42.7.1, [31;1m647.3 KiB[0m
electron: 41.9.1, 42.5.1 → 41.10.3, 42.7.1
gtk+: 2.24.33 → ∅, [32;1m-27.1 MiB[0m
home-manager: [31;1m10.2 KiB[0m
mesa: 26.1.5 → 26.1.6, [31;1m13.0 KiB[0m
mesa: 26.1.5 → 26.1.6, [31;1m27.9 KiB[0m
mullvad-vpn: [31;1m136.1 KiB[0m
mullvad: [32;1m-319.5 KiB[0m
nixos-manual: [31;1m27.0 KiB[0m
nixos-system-arcade: 26.11.20260729.9bc0289 → 26.11.20260731.59ea0b1
nixos-system-kushtaka: 26.11.20260729.9bc0289 → 26.11.20260731.59ea0b1
nixos-system-snallygaster: 26.11.20260729.9bc0289 → 26.11.20260731.59ea0b1
nixos-system-wendigo: 26.11.20260729.9bc0289 → 26.11.20260731.59ea0b1
nodejs-slim: 22.23.1 → 22.23.2
nodejs: 22.23.1 → 22.23.2
source: [32;1m-30.4 KiB[0m
tailscale: 1.98.9 → 1.98.10, [31;1m20.2 KiB[0m
xh: 0.26.1 → 0.26.2, [31;1m53.7 KiB[0m
```

</details>