### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -56,11 +56,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1785559318,
-        "narHash": "sha256-u5aemaCnIh6NymKZE5PXcxAwMLH8vfD1MFl/CUJ1Ow4=",
+        "lastModified": 1785605734,
+        "narHash": "sha256-wfQPXddQ6aoMOBmKQgWSn/fCAi2bg3QzTpMSA+PL3jQ=",
         "owner": "charmbracelet",
         "repo": "nur",
-        "rev": "ad72c13b7374e7153db65829a6ab69c6c272bcac",
+        "rev": "cd337c925c6e414c124c934d3c32fa57b43dd6eb",
         "type": "github"
       },
       "original": {
@@ -275,11 +275,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785046085,
-        "narHash": "sha256-UiK+mmZJuLWQVhJ5b2wDzogIYWAesyRm6LA3h3Ulh3Y=",
+        "lastModified": 1785650611,
+        "narHash": "sha256-q4kR7g+pCcz6NASvoVPYu+CWWUurX03wogtBqGmR4h0=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "11665045df8b9938ef811a3bfdc65cffb02b4b70",
+        "rev": "dbc756c9d7287de19b3e0e38c928c47510d42c3e",
         "type": "github"
       },
       "original": {
@@ -394,11 +394,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1785483748,
-        "narHash": "sha256-M4HXpLsR7iFTNQfD/q+zK8/QeRYztYVDVIdIgCVGGZ0=",
+        "lastModified": 1785747939,
+        "narHash": "sha256-D740uKsMbgsfK2oaDenJLLPIZfq7W0/g4KN/Fls8eKs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "59ea0b1c043c463e39fcb3cfb9a5c8bcf0777c72",
+        "rev": "104240a772428cc2e20d8fd86c9ddbb886bbaff2",
         "type": "github"
       },
       "original": {
@@ -410,11 +410,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1785454630,
-        "narHash": "sha256-LQy14TZp77TwbQf40gg1V3jo8FwJG0jGDkAH+zRHqg8=",
+        "lastModified": 1785692966,
+        "narHash": "sha256-vUfIeBEfpbAfZ5zjgIkYk7eHBeVfCYVjLbWnMkseYnk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1559d3daa3ecc813a650b79375ea61b6741b8746",
+        "rev": "643809054d65fdd466a63e3155b8c498cb483c04",
         "type": "github"
       },
       "original": {
@@ -430,11 +430,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1785578044,
-        "narHash": "sha256-bVjc5fQ1TLoQgYkjp6bJTesX2QbIst2te4rTHJhj62Q=",
+        "lastModified": 1785840024,
+        "narHash": "sha256-spwATd2pE9T0ofnjRdWosQoWnFh6uxaQUONQC9qPJLU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9d367a00c93c42f1ae2fa500c2a5dc3aca04d636",
+        "rev": "b44d641ce5984efd33374ab972f8e104a4015ead",
         "type": "github"
       },
       "original": {
@@ -569,11 +569,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1785577472,
-        "narHash": "sha256-UpBE/05qbT9Nd7dO3zOP7nQvo0kSEDOf/9zDj9dXB7A=",
+        "lastModified": 1785832414,
+        "narHash": "sha256-+lv9f6Vw7dw62QHPRW1uXEm8c3pwYUQ4Yz71OaUqEws=",
         "owner": "oraios",
         "repo": "serena",
-        "rev": "c74373e29a8bdafdbfc6c6a8f7d7b92301ae1f81",
+        "rev": "e6b3852117b0e53f9233c03fc2ccaaf8b17b542c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated update of `flake.lock` inputs.

All hosts built successfully against this lock file.
Merging will trigger `autodeploy.yaml`, which publishes store paths for pickup by `nixos-autodeploy`.

## Package changes

**Added: 0
0 | Removed: 0
0 | Changed: **

<details>
<summary>Full diff</summary>

```
SDL2_ttf: 2.24.0 → ∅, [32;1m-92.6 KiB[0m
akonadi: [31;1m8.0 KiB[0m
atuin: 18.18.0 → 18.18.1, [31;1m27.6 KiB[0m
audit: 4.1.4 → 4.2
bat: [31;1m9.1 KiB[0m
bind: 9.20.24 → 9.20.26, [31;1m8.9 KiB[0m
clang: 21.1.8 → ∅, [32;1m-1.6 GiB[0m
clang: 21.1.8 → ∅, [32;1m-863.7 MiB[0m
cxx-rust-cssparser: [31;1m17.1 KiB[0m
dash: 0.5.13.4 → 0.5.13.5
electron-unwrapped: 42.7.1 → 43.2.0, [31;1m3.9 MiB[0m
electron: 42.7.1 → 43.2.0
ethtool: 7.0 → 7.1
findutils: 4.10.0 → 4.11.0, [31;1m172.4 KiB[0m
firefox-unwrapped: [31;1m92.6 KiB[0m
fluidsynth: 2.5.5 → 2.5.6
fontconfig: 2.18.1 → 2.18.2, [31;1m230.9 KiB[0m
fzf: 0.74.1 → 0.74.2, [31;1m20.1 KiB[0m
geoclue: 2.7.2 → 2.8.1, [31;1m43.7 KiB[0m
gh: 2.96.0 → 2.97.0, [31;1m262.3 KiB[0m
gofumpt: 0.10.0 → 0.11.0
gst-plugins-bad: 1.28.4 → 1.28.5, [31;1m17.5 KiB[0m
gst-plugins-base: 1.28.4 → 1.28.5
gst-plugins-good: 1.28.4 → 1.28.5
gstreamer: 1.28.4 → 1.28.5, [31;1m12.2 KiB[0m
gstreamer: 1.28.4 → 1.28.5, [31;1m12.6 KiB[0m
ijq: 1.3.0 → 1.4.0, [31;1m28.4 KiB[0m
imagemagick: 7.1.2-27 → 7.1.2-29, [31;1m71.2 KiB[0m
index-x86_64-linux: [31;1m16.9 KiB[0m
index-x86_64: [31;1m1.2 MiB[0m
initrd-linux: 6.18.40 → 6.18.41, [31;1m260.1 KiB[0m
initrd-linux: 6.18.40 → 6.18.41, [31;1m272.3 KiB[0m
initrd-linux: 6.18.40 → 6.18.41, [31;1m281.2 KiB[0m
initrd-linux: 6.18.40 → 6.18.41, [31;1m388.4 KiB[0m
jujutsu: [31;1m194.6 KiB[0m
kitty: 0.48.1 → 0.48.2, [31;1m47.2 KiB[0m
ktextaddons: 2.1.1 → 2.1.2, [32;1m-13.5 KiB[0m
libapparmor: 5.0.1 → 5.0.2
libdovi: [32;1m-11.0 KiB[0m
libffi: 3.7.0 → 3.7.1
libmicrohttpd: 1.0.5 → 1.0.6
libmysofa: 1.3.3 → 1.3.4
libplasma: [32;1m-16.9 KiB[0m
libretro-genesis-plus-gx: 0-unstable-2026-07-10 → 0-unstable-2026-07-27
libretro-mgba: 0-unstable-2026-04-03 → 0-unstable-2026-07-28
libsodium: 1.0.22-unstable-2026-04-16 → 1.0.22-unstable-2026-07-08
libssh: 0.12.0 → 0.12.1
libtiff: 4.7.1 → 4.7.2, [31;1m22.1 KiB[0m
libtiff: 4.7.1 → 4.7.2, [31;1m43.2 KiB[0m
libtool: 2.5.4 → 2.6.2
libvlc: [32;1m-32.3 KiB[0m
linux-headers-static: 7.0 → 7.1, [31;1m27.2 KiB[0m
linux-headers: 7.0 → 7.1, [31;1m27.2 KiB[0m
linux: 6.18.40 → 6.18.41, [32;1m-16.4 KiB[0m
llvm: [32;1m-527.8 MiB[0m
lnav: [32;1m-65.5 KiB[0m
mame: [32;1m-44.5 KiB[0m
mbedtls: 3.6.6 → 3.6.7, [31;1m22.4 KiB[0m
mbedtls: 3.6.6 → 3.6.7, [31;1m8.6 KiB[0m
mise: 2026.7.10 → 2026.7.17, [31;1m22.0 MiB[0m
nfs-utils: 2.9.1 → 2.9.2, [31;1m19.1 KiB[0m
nixos-manual: [31;1m72.8 KiB[0m
nixos-system-arcade: 26.11.20260731.59ea0b1 → 26.11.20260803.104240a
nixos-system-kushtaka: 26.11.20260731.59ea0b1 → 26.11.20260803.104240a
nixos-system-snallygaster: 26.11.20260731.59ea0b1 → 26.11.20260803.104240a
nixos-system-wendigo: 26.11.20260731.59ea0b1 → 26.11.20260803.104240a
nodejs-slim: 24.18.0 → 24.18.1
nodejs: 24.18.0 → 24.18.1
nss-cacert: 3.125, 3.125-p11kit → 3.126, 3.126-p11kit, [31;1m28.1 KiB[0m
obsidian: 1.12.7 → 1.13.4, [31;1m2.0 MiB[0m
openexr: 3.4.11 → 3.4.13, [31;1m12.9 KiB[0m
openjdk-minimal-jre: 21.0.12+2 → 21.0.12+8, [32;1m-32.5 KiB[0m
openjdk: 21.0.12+2 → 21.0.12+8, [31;1m364.0 KiB[0m
perl5.42.0-Mozilla-CA: [31;1m11.5 KiB[0m
plutosvg: ∅ → 0.0.8, [31;1m76.2 KiB[0m
plutovg: ∅ → 1.3.3, [31;1m480.5 KiB[0m
prison: [32;1m-9.7 KiB[0m
python3.14-certifi: [31;1m11.5 KiB[0m
python3.14-gst-python: 1.28.4 → 1.28.5
python3: [32;1m-19.4 KiB[0m
ruff: 0.15.22 → 0.16.1, [31;1m217.3 KiB[0m
s2n-tls: 1.7.2 → 1.7.6, [31;1m19.5 KiB[0m
sdl3-ttf: ∅ → 3.2.2, [31;1m316.6 KiB[0m
sdl3: [31;1m4.7 MiB[0m
serena-agent: [31;1m25.9 KiB[0m
signal-desktop: 8.18.0 → 8.21.0, [31;1m5.0 MiB[0m
sox-unstable: 2021-05-09 → ∅, [32;1m-1.4 MiB[0m
sox-unstable: 2021-05-09 → ∅, [32;1m-701.6 KiB[0m
sox: ∅ → 14.4.2-unstable-2021-05-09, [31;1m1.4 MiB[0m
sox: ∅ → 14.4.2-unstable-2021-05-09, [31;1m701.6 KiB[0m
srt: 1.5.5 → 1.5.6, [31;1m38.1 KiB[0m
srt: 1.5.5 → 1.5.6, [31;1m89.9 KiB[0m
starship: [31;1m184.6 KiB[0m
steam-run: [32;1m-126.8 KiB[0m
steam: [32;1m-125.9 KiB[0m
subversion-client: [32;1m-8.0 KiB[0m
systemd-minimal-libs: 261 → 261.1
systemd-minimal: 261 → 261.1, [31;1m14.5 KiB[0m
systemd: 261 → 261.1, [31;1m62.1 MiB[0m
systemd: 261 → 261.1, [31;1m62.2 MiB[0m
tzdata: 2026b → 2026c, [32;1m-18.8 KiB[0m
tzdata: 2026b → 2026c, [32;1m-9.4 KiB[0m
unbound: 1.25.1 → 1.25.2, [31;1m8.1 KiB[0m
upower: 1.91.1 → 1.91.2
vimplugin-fzf: 0.74.1 → 0.74.2, [31;1m30.5 KiB[0m
vlc: [32;1m-28.3 KiB[0m
x86_energy_perf_policy: 6.18.40 → 6.18.41
xdg-desktop-portal: 1.20.4 → 1.22.1, [31;1m127.5 KiB[0m
zint: ∅ → 2.16.0, [31;1m1013.9 KiB[0m
zxing-cpp: 2.3.0 → 3.0.2, [32;1m-198.3 KiB[0m
```

</details>